### PR TITLE
Feat/buyers pet/8

### DIFF
--- a/src/main/java/com/team5/catdogeats/global/config/JpaConfig.java
+++ b/src/main/java/com/team5/catdogeats/global/config/JpaConfig.java
@@ -14,7 +14,7 @@ import javax.sql.DataSource;
 
 @Configuration
 @EnableJpaRepositories(
-        basePackages = "com.team5.catdogeats.users.repository",
+        basePackages = {"com.team5.catdogeats.users.repository", "com.team5.catdogeats.pets.repository"},
         entityManagerFactoryRef = "entityManagerFactory",
         transactionManagerRef = "jpaTransactionManager"
 )

--- a/src/main/java/com/team5/catdogeats/global/exception/CustomException.java
+++ b/src/main/java/com/team5/catdogeats/global/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.team5.catdogeats.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+    private final HttpStatus status;
+
+    public CustomException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/team5/catdogeats/global/exception/ErrorResponse.java
+++ b/src/main/java/com/team5/catdogeats/global/exception/ErrorResponse.java
@@ -1,0 +1,3 @@
+package com.team5.catdogeats.global.exception;
+
+public record ErrorResponse(String message) {}

--- a/src/main/java/com/team5/catdogeats/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team5/catdogeats/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.team5.catdogeats.global.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ResponseEntity.status(e.getStatus())
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("서버 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/team5/catdogeats/pets/controller/PetController.java
+++ b/src/main/java/com/team5/catdogeats/pets/controller/PetController.java
@@ -1,0 +1,53 @@
+package com.team5.catdogeats.pets.controller;
+
+import com.team5.catdogeats.pets.domain.dto.*;
+import com.team5.catdogeats.pets.service.PetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/buyers")
+@RequiredArgsConstructor
+@Tag(name = "Pet", description = "펫 정보 관련 API")
+public class PetController {
+
+    private final PetService petService;
+
+    @Operation(summary = "펫 등록", description = "새로운 펫 정보를 등록합니다.")
+    @PostMapping("/pet")
+    public ResponseEntity<Void> registerPet(@RequestBody @Valid @Parameter(description = "등록할 펫 정보", required = true) PetCreateRequestDto dto) {
+        UUID petId = petService.registerPet(dto);
+        return ResponseEntity.created(URI.create("/v1/buyers/pet/" + petId)).build();
+    }
+
+    @Operation(summary = "내 펫 목록 조회", description = "로그인한 사용자의 펫 목록을 조회합니다.")
+    @GetMapping("/pet")
+    public ResponseEntity<ApiResponse<List<PetResponseDto>>> getMyPets() {
+        return ResponseEntity.ok(ApiResponse.of(petService.getMyPets()));
+    }
+
+    @Operation(summary = "펫 정보 수정", description = "기존 펫 정보를 수정합니다.")
+    @PatchMapping("/pet")
+    public ResponseEntity<Void> updatePet(@RequestBody @Valid @Parameter(description = "수정할 펫 정보", required = true) PetUpdateRequestDto dto) {
+        petService.updatePet(dto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "펫 삭제", description = "펫 정보를 삭제합니다.")
+    @DeleteMapping("/pet")
+    public ResponseEntity<Void> deletePet(@RequestBody @Valid @Parameter(description = "삭제할 펫 id", required = true) PetDeleteRequestDto dto) {
+        petService.deletePet(dto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/team5/catdogeats/pets/domain/Pets.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/Pets.java
@@ -1,6 +1,8 @@
 package com.team5.catdogeats.pets.domain;
 
 import com.team5.catdogeats.baseEntity.BaseEntity;
+import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
+import com.team5.catdogeats.pets.domain.dto.PetUpdateRequestDto;
 import com.team5.catdogeats.pets.domain.enums.Gender;
 import com.team5.catdogeats.pets.domain.enums.PetCategory;
 import com.team5.catdogeats.users.domain.mapping.Buyers;
@@ -41,4 +43,23 @@ public class Pets extends BaseEntity {
 
     @Column
     private Short age;
+
+    public static Pets fromDto(PetCreateRequestDto dto, Buyers buyer) {
+        return Pets.builder()
+                .buyer(buyer)
+                .name(dto.name())
+                .petCategory(dto.petCategory())
+                .gender(dto.gender())
+                .breed(dto.breed())
+                .age(dto.age())
+                .build();
+    }
+
+    public void updateFromDto(PetUpdateRequestDto dto) {
+        if (dto.name() != null) this.name = dto.name();
+        if (dto.petCategory() != null) this.petCategory = dto.petCategory();
+        if (dto.gender() != null) this.gender = dto.gender();
+        if (dto.breed() != null) this.breed = dto.breed();
+        if (dto.age() != null) this.age = dto.age();
+    }
 }

--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/ApiResponse.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/ApiResponse.java
@@ -1,0 +1,7 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+public record ApiResponse<T>(T data) {
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+}

--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/PetCreateRequestDto.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/PetCreateRequestDto.java
@@ -1,0 +1,26 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+import com.team5.catdogeats.pets.domain.enums.Gender;
+import com.team5.catdogeats.pets.domain.enums.PetCategory;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PetCreateRequestDto(
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @NotNull(message = "카테고리는 필수입니다.")
+        PetCategory petCategory,
+
+        @NotNull(message = "성별은 필수입니다.")
+        Gender gender,
+
+        @NotBlank(message = "품종은 필수입니다.")
+        String breed,
+
+        @NotNull(message = "나이는 필수입니다.")
+        @Min(value = 0, message = "나이는 0 이상이어야 합니다.")
+        Short age
+) {
+}

--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/PetDeleteRequestDto.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/PetDeleteRequestDto.java
@@ -1,0 +1,8 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+import java.util.UUID;
+
+public record PetDeleteRequestDto(
+        UUID petId
+) {
+}

--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/PetResponseDto.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/PetResponseDto.java
@@ -1,0 +1,23 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+import com.team5.catdogeats.pets.domain.Pets;
+import com.team5.catdogeats.pets.domain.enums.Gender;
+import com.team5.catdogeats.pets.domain.enums.PetCategory;
+
+import java.util.UUID;
+
+public record PetResponseDto(
+        UUID id,
+        String name,
+        PetCategory petCategory,
+        Gender gender,
+        String breed,
+        Short age
+) {
+    public static PetResponseDto fromEntity(Pets pet) {
+        return new PetResponseDto(
+                pet.getId(), pet.getName(), pet.getPetCategory(),
+                pet.getGender(), pet.getBreed(), pet.getAge()
+        );
+    }
+}

--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/PetUpdateRequestDto.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/PetUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+import com.team5.catdogeats.pets.domain.enums.Gender;
+import com.team5.catdogeats.pets.domain.enums.PetCategory;
+
+import java.util.UUID;
+
+public record PetUpdateRequestDto(
+        UUID petId,
+        String name,
+        PetCategory petCategory,
+        Gender gender,
+        String breed,
+        Short age
+) {
+}

--- a/src/main/java/com/team5/catdogeats/pets/repository/PetRepository.java
+++ b/src/main/java/com/team5/catdogeats/pets/repository/PetRepository.java
@@ -1,0 +1,12 @@
+package com.team5.catdogeats.pets.repository;
+
+import com.team5.catdogeats.pets.domain.Pets;
+import com.team5.catdogeats.users.domain.mapping.Buyers;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PetRepository extends JpaRepository<Pets, UUID> {
+    List<Pets> findByBuyer(Buyers buyer);
+}

--- a/src/main/java/com/team5/catdogeats/pets/service/PetService.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/PetService.java
@@ -1,0 +1,16 @@
+package com.team5.catdogeats.pets.service;
+
+import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
+import com.team5.catdogeats.pets.domain.dto.PetDeleteRequestDto;
+import com.team5.catdogeats.pets.domain.dto.PetResponseDto;
+import com.team5.catdogeats.pets.domain.dto.PetUpdateRequestDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PetService {
+    UUID registerPet(PetCreateRequestDto dto);
+    List<PetResponseDto> getMyPets();
+    void updatePet(PetUpdateRequestDto dto);
+    void deletePet(PetDeleteRequestDto dto);
+}

--- a/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
@@ -53,7 +53,7 @@ public class PetServiceImpl implements PetService {
     @Override
     public void updatePet(PetUpdateRequestDto dto) {
         Pets pet = petRepository.findById(dto.petId())
-                .orElseThrow(() -> new CustomException("펫 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("해당하는 펫의 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
 
         pet.updateFromDto(dto);
     }
@@ -61,7 +61,7 @@ public class PetServiceImpl implements PetService {
     @Override
     public void deletePet(PetDeleteRequestDto dto) {
         Pets pet = petRepository.findById(dto.petId())
-                .orElseThrow(() -> new CustomException("펫 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("해당하는 펫의 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
 
         petRepository.deleteById(dto.petId());
     }

--- a/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
@@ -1,0 +1,68 @@
+package com.team5.catdogeats.pets.service.impl;
+
+import com.team5.catdogeats.global.exception.CustomException;
+import com.team5.catdogeats.pets.domain.Pets;
+import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
+import com.team5.catdogeats.pets.domain.dto.PetDeleteRequestDto;
+import com.team5.catdogeats.pets.domain.dto.PetResponseDto;
+import com.team5.catdogeats.pets.domain.dto.PetUpdateRequestDto;
+import com.team5.catdogeats.pets.repository.PetRepository;
+import com.team5.catdogeats.pets.service.PetService;
+import com.team5.catdogeats.users.domain.mapping.Buyers;
+import com.team5.catdogeats.users.repository.BuyerRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PetServiceImpl implements PetService {
+
+    private final PetRepository petRepository;
+    private final BuyerRepository buyerRepository;
+
+    @Override
+    public UUID registerPet(PetCreateRequestDto dto) {
+//      TODO: UUID userId = SecurityUtil.getCurrentUserId();
+        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        Buyers buyer = buyerRepository.findById(userId)
+                .orElseThrow(() -> new CustomException("해당 유저가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        Pets pet = Pets.fromDto(dto, buyer);
+        return petRepository.save(pet).getId();
+    }
+
+    @Override
+    public List<PetResponseDto> getMyPets() {
+//      TODO:  UUID userId = SecurityUtil.getCurrentUserId();
+        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        Buyers buyer = buyerRepository.findById(userId)
+                .orElseThrow(() -> new CustomException("해당 유저가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        return petRepository.findByBuyer(buyer)
+                .stream()
+                .map(PetResponseDto::fromEntity)
+                .toList();
+    }
+
+    @Transactional
+    @Override
+    public void updatePet(PetUpdateRequestDto dto) {
+        Pets pet = petRepository.findById(dto.petId())
+                .orElseThrow(() -> new CustomException("펫 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        pet.updateFromDto(dto);
+    }
+
+    @Override
+    public void deletePet(PetDeleteRequestDto dto) {
+        Pets pet = petRepository.findById(dto.petId())
+                .orElseThrow(() -> new CustomException("펫 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        petRepository.deleteById(dto.petId());
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 펫 정보 관련 CRUD api 구현
---

## 📄 개요
Pet Entity 관련한 repository, service, controller 추가
- 

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [ ] 기능 구현
- [ ] UI/UX 수정
- [ ] API 연동
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서 작성

---

## 📃 작업 세부 내용
Pets Entity 관련 조회, 등록, 수정, 삭제 api 구현 및 JMeter 통한 성능 테스트

---

## 테스트 설정
- 조회: Threads=100, Ramp-up=5s, Loop Count=20 → 총 2,000건
- 등록/수정/삭제: Threads=50, Ramp-up=10s, Loop Count=3 → 각 150건

---

### 테스트 결과

### 🐾 조회 API
![pet조회성능](https://github.com/user-attachments/assets/46a7a964-bb1d-4978-87b1-3b84dc7c8a2f)

- 평균 응답 시간: 3,080ms
- 처리량: 29.6/sec
- 에러율: 0.00%
- 응답 시간: min 267ms / max 6,073ms
- 평균 바이트: 430.0

### 🐶 등록 API
![pet등록성능](https://github.com/user-attachments/assets/eb8cfd87-694b-473e-be41-c84cad700159)

- 평균 응답 시간: 6,529ms ⚠️
- 처리량: 4.9/sec
- 에러율: 0.00%
- 응답 시간: min 1,378ms / max 10,382ms
- 표준 편차: 1,469.21ms → 편차 매우 큼
- 평균 바이트: 184.0

### 📝 수정 API
![pet수정성능](https://github.com/user-attachments/assets/c4b6ba7c-ba6e-434c-b46c-2f2c27f3221e)

- 평균 응답 시간: 494ms
- 처리량: 12.9/sec
- 에러율: 0.67% (1건, 잘못된 petId - UUID 형태가 아닌 String형태)
- 응답 시간: min 6ms / max 1,040ms

### ❌ 삭제 API
![pet삭제성능](https://github.com/user-attachments/assets/cfa7acee-6856-4c16-a2aa-96cc913da8ab)

- 평균 응답 시간: 1,698ms
- 처리량: 10.2/sec
- 에러율: 0.67% (1건, 잘못된 petId - UUID 형태가 아닌 String형태)
- 응답 시간: min 110ms / max 3,011ms

---
### 결과 분석
| 항목 | 평균 응답 시간 | 에러율 | 처리량 (TPS) | 비고 | 
|--------|----------------|---------|--------------|------------------------------|
| 조회 | 3,080ms | 0.00% | 29.6/sec | 고트래픽 대응 가능, 안정적 | 
| 등록 | 6,529ms | 0.00% | 4.9/sec | 처리 속도 느림, 개선 필요 |
| 수정 | 494ms | 0.67% | 12.9/sec | 안정적 성능, 1건 테스트 오류 | 
| 삭제 | 1,698ms | 0.67% | 10.2/sec | 평균 속도 중간, 1건 테스트 오류 | 

---

## 🔍 관련 이슈
- #8 

---

## 📝 참고 사항
- 

---

## 🙏 리뷰 요청 사항
- 
