### PR TITLE
[Refactor] ResponseCode enum 도입으로 API 응답 관리

### DIFF
--- a/src/main/java/com/team5/catdogeats/global/dto/ApiResponse.java
+++ b/src/main/java/com/team5/catdogeats/global/dto/ApiResponse.java
@@ -1,57 +1,152 @@
 package com.team5.catdogeats.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.team5.catdogeats.global.enums.ResponseCode;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 전역 API 응답 포맷
  * 모든 REST API 응답에서 사용하는 공통 응답 구조
  */
-public record ApiResponse<T>(
-        boolean success,
-        String message,
-        T data,
-        LocalDateTime timestamp,
-        String path,
-        List<FieldError> errors
-) {
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean success; // 성공 여부
+    private final int status; // HTTP 상태 코드
+    private final String code; // ResponseCode의 이름 (e.g., "SUCCESS", "USER_NOT_FOUND")
+    private final String message; // 응답 메시지
+    private final LocalDateTime timestamp; // 응답 시간
+
+    @JsonInclude(JsonInclude.Include.NON_NULL) // data가 null이면 응답 JSON에서 제외
+    private final T data; // 실제 응답 데이터
+
+    // 성공 시 (데이터 포함)
+    private ApiResponse(ResponseCode responseCode, T data) {
+        this.success = true;
+        this.status = responseCode.getStatus().value();
+        this.code = responseCode.name();
+        this.message = responseCode.getMessage();
+        this.timestamp = LocalDateTime.now();
+        this.data = data;
+    }
+
+    // 성공 시 (데이터 없음)
+    private ApiResponse(ResponseCode responseCode) {
+        this.success = true;
+        this.status = responseCode.getStatus().value();
+        this.code = responseCode.name();
+        this.message = responseCode.getMessage();
+        this.timestamp = LocalDateTime.now();
+        this.data = null;
+    }
+
+    // 성공 시 (커스텀 메시지)
+    private ApiResponse(ResponseCode responseCode, String customMessage, T data) {
+        this.success = true;
+        this.status = responseCode.getStatus().value();
+        this.code = responseCode.name();
+        this.message = customMessage;
+        this.timestamp = LocalDateTime.now();
+        this.data = data;
+    }
+
+    // 실패 시 (기본 메시지)
+    private ApiResponse(ResponseCode responseCode, boolean success) {
+        this.success = success;
+        this.status = responseCode.getStatus().value();
+        this.code = responseCode.name();
+        this.message = responseCode.getMessage();
+        this.timestamp = LocalDateTime.now();
+        this.data = null;
+    }
+
+    // 실패 시 (커스텀 메시지)
+    private ApiResponse(ResponseCode responseCode, String customMessage, boolean success) {
+        this.success = success;
+        this.status = responseCode.getStatus().value();
+        this.code = responseCode.name();
+        this.message = customMessage;
+        this.timestamp = LocalDateTime.now();
+        this.data = null;
+    }
+
+    // === 정적 팩토리 메서드 ===
+
+    // 성공 (데이터 포함)
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(ResponseCode.SUCCESS, data);
+    }
+
+    // 성공 (데이터 없음)
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(ResponseCode.SUCCESS);
+    }
+
+    // 성공 (특정 ResponseCode 사용, 데이터 포함)
+    public static <T> ApiResponse<T> success(ResponseCode responseCode, T data) {
+        return new ApiResponse<>(responseCode, data);
+    }
+
+    // 성공 (특정 ResponseCode 사용, 데이터 없음)
+    public static <T> ApiResponse<T> success(ResponseCode responseCode) {
+        return new ApiResponse<>(responseCode);
+    }
+
+    // 성공 (커스텀 메시지 사용, 데이터 포함)
+    public static <T> ApiResponse<T> success(ResponseCode responseCode, String message, T data) {
+        return new ApiResponse<>(responseCode, message, data);
+    }
+
+    // 성공 (커스텀 메시지 사용, 데이터 없음)
+    public static <T> ApiResponse<T> success(ResponseCode responseCode, String message) {
+        return new ApiResponse<>(responseCode, message, null);
+    }
+
+    // 성공 (CREATED 상태 코드 사용, 데이터 포함)
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(ResponseCode.CREATED, data);
+    }
+
+    // 실패 (기본 메시지 사용)
+    public static <T> ApiResponse<T> error(ResponseCode responseCode) {
+        return new ApiResponse<>(responseCode, false);
+    }
+
+    // 실패 (커스텀 메시지 사용)
+    public static <T> ApiResponse<T> error(ResponseCode responseCode, String message) {
+        return new ApiResponse<>(responseCode, message, false);
+    }
+
+    // === 기존 호환성을 위한 메서드들 (deprecated 처리 예정) ===
+
     /**
-     * 성공 응답 생성
+     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
      */
+    @Deprecated
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(
-                true,
-                message,
-                data,
-                LocalDateTime.now(),
-                null,
-                null
-        );
+        return new ApiResponse<>(ResponseCode.SUCCESS, message, data);
     }
 
     /**
-     * 실패 응답 생성
+     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
      */
-    public static <T> ApiResponse<T> error(String message, String path, List<FieldError> errors) {
-        return new ApiResponse<>(
-                false,
-                message,
-                null,
-                LocalDateTime.now(),
-                path,
-                errors
-        );
+    @Deprecated
+    public static <T> ApiResponse<T> error(String message, String path, java.util.List<FieldError> errors) {
+        return new ApiResponse<>(ResponseCode.INVALID_INPUT_VALUE, message, false);
     }
 
     /**
-     * 단순 에러 응답 생성 (필드 에러 없이)
+     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
      */
+    @Deprecated
     public static <T> ApiResponse<T> error(String message, String path) {
-        return error(message, path, null);
+        return new ApiResponse<>(ResponseCode.INTERNAL_SERVER_ERROR, message, false);
     }
 
     /**
-     * 필드 에러 정보
+     * 필드 에러 정보 (기존 호환성 유지)
      */
     public record FieldError(
             String field,

--- a/src/main/java/com/team5/catdogeats/global/dto/ApiResponse.java
+++ b/src/main/java/com/team5/catdogeats/global/dto/ApiResponse.java
@@ -1,155 +1,93 @@
 package com.team5.catdogeats.global.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.team5.catdogeats.global.enums.ResponseCode;
-import lombok.Getter;
+import org.springframework.validation.FieldError;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
 
 /**
  * 전역 API 응답 포맷
  * 모든 REST API 응답에서 사용하는 공통 응답 구조
  */
-@Getter
-public class ApiResponse<T> {
+public record ApiResponse<T>(
+        boolean success,
+        String message,
+        T data,
+        ZonedDateTime timestamp,
+        String path,
+        List<FieldError> errors
+) {
+    // === ResponseCode 기반 새로운 팩토리 메서드들 ===
 
-    private final boolean success; // 성공 여부
-    private final int status; // HTTP 상태 코드
-    private final String code; // ResponseCode의 이름 (e.g., "SUCCESS", "USER_NOT_FOUND")
-    private final String message; // 응답 메시지
-    private final LocalDateTime timestamp; // 응답 시간
-
-    @JsonInclude(JsonInclude.Include.NON_NULL) // data가 null이면 응답 JSON에서 제외
-    private final T data; // 실제 응답 데이터
-
-    // 성공 시 (데이터 포함)
-    private ApiResponse(ResponseCode responseCode, T data) {
-        this.success = true;
-        this.status = responseCode.getStatus().value();
-        this.code = responseCode.name();
-        this.message = responseCode.getMessage();
-        this.timestamp = LocalDateTime.now();
-        this.data = data;
-    }
-
-    // 성공 시 (데이터 없음)
-    private ApiResponse(ResponseCode responseCode) {
-        this.success = true;
-        this.status = responseCode.getStatus().value();
-        this.code = responseCode.name();
-        this.message = responseCode.getMessage();
-        this.timestamp = LocalDateTime.now();
-        this.data = null;
-    }
-
-    // 성공 시 (커스텀 메시지)
-    private ApiResponse(ResponseCode responseCode, String customMessage, T data) {
-        this.success = true;
-        this.status = responseCode.getStatus().value();
-        this.code = responseCode.name();
-        this.message = customMessage;
-        this.timestamp = LocalDateTime.now();
-        this.data = data;
-    }
-
-    // 실패 시 (기본 메시지)
-    private ApiResponse(ResponseCode responseCode, boolean success) {
-        this.success = success;
-        this.status = responseCode.getStatus().value();
-        this.code = responseCode.name();
-        this.message = responseCode.getMessage();
-        this.timestamp = LocalDateTime.now();
-        this.data = null;
-    }
-
-    // 실패 시 (커스텀 메시지)
-    private ApiResponse(ResponseCode responseCode, String customMessage, boolean success) {
-        this.success = success;
-        this.status = responseCode.getStatus().value();
-        this.code = responseCode.name();
-        this.message = customMessage;
-        this.timestamp = LocalDateTime.now();
-        this.data = null;
-    }
-
-    // === 정적 팩토리 메서드 ===
-
-    // 성공 (데이터 포함)
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(ResponseCode.SUCCESS, data);
-    }
-
-    // 성공 (데이터 없음)
-    public static <T> ApiResponse<T> success() {
-        return new ApiResponse<>(ResponseCode.SUCCESS);
-    }
-
-    // 성공 (특정 ResponseCode 사용, 데이터 포함)
+    /**
+     * 성공 응답 생성
+     */
     public static <T> ApiResponse<T> success(ResponseCode responseCode, T data) {
-        return new ApiResponse<>(responseCode, data);
+        return new ApiResponse<>(
+                true,
+                responseCode.getMessage(),
+                data,
+                ZonedDateTime.now(),
+                null,
+                null
+        );
     }
 
-    // 성공 (특정 ResponseCode 사용, 데이터 없음)
+    /**
+     * 성공 응답 생성 (데이터 없음)
+     */
     public static <T> ApiResponse<T> success(ResponseCode responseCode) {
-        return new ApiResponse<>(responseCode);
+        return new ApiResponse<>(
+                true,
+                responseCode.getMessage(),
+                null,
+                ZonedDateTime.now(),
+                null,
+                null
+        );
     }
 
-    // 성공 (커스텀 메시지 사용, 데이터 포함)
-    public static <T> ApiResponse<T> success(ResponseCode responseCode, String message, T data) {
-        return new ApiResponse<>(responseCode, message, data);
-    }
-
-    // 성공 (커스텀 메시지 사용, 데이터 없음)
-    public static <T> ApiResponse<T> success(ResponseCode responseCode, String message) {
-        return new ApiResponse<>(responseCode, message, null);
-    }
-
-    // 성공 (CREATED 상태 코드 사용, 데이터 포함)
-    public static <T> ApiResponse<T> created(T data) {
-        return new ApiResponse<>(ResponseCode.CREATED, data);
-    }
-
-    // 실패 (기본 메시지 사용)
+    /**
+     * 실패 응답 생성
+     */
     public static <T> ApiResponse<T> error(ResponseCode responseCode) {
-        return new ApiResponse<>(responseCode, false);
-    }
-
-    // 실패 (커스텀 메시지 사용)
-    public static <T> ApiResponse<T> error(ResponseCode responseCode, String message) {
-        return new ApiResponse<>(responseCode, message, false);
-    }
-
-    // === 기존 호환성을 위한 메서드들 (deprecated 처리 예정) ===
-
-    /**
-     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
-     */
-    @Deprecated
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(ResponseCode.SUCCESS, message, data);
+        return new ApiResponse<>(
+                false,
+                responseCode.getMessage(),
+                null,
+                ZonedDateTime.now(),
+                null,
+                null
+        );
     }
 
     /**
-     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
+     * 실패 응답 생성 (커스텀 메시지)
      */
-    @Deprecated
-    public static <T> ApiResponse<T> error(String message, String path, java.util.List<FieldError> errors) {
-        return new ApiResponse<>(ResponseCode.INVALID_INPUT_VALUE, message, false);
+    public static <T> ApiResponse<T> error(ResponseCode responseCode, String customMessage) {
+        return new ApiResponse<>(
+                false,
+                customMessage,
+                null,
+                ZonedDateTime.now(),
+                null,
+                null
+        );
     }
 
     /**
-     * @deprecated ResponseCode를 사용하는 방식으로 변경해주세요
+     * 실패 응답 생성 (path)
      */
-    @Deprecated
-    public static <T> ApiResponse<T> error(String message, String path) {
-        return new ApiResponse<>(ResponseCode.INTERNAL_SERVER_ERROR, message, false);
+    public static <T> ApiResponse<T> error(ResponseCode responseCode, String path, List<FieldError> errors) {
+        return new ApiResponse<>(
+                false,
+                responseCode.getMessage(),
+                null,
+                ZonedDateTime.now(),
+                path,
+                errors
+        );
     }
 
-    /**
-     * 필드 에러 정보 (기존 호환성 유지)
-     */
-    public record FieldError(
-            String field,
-            String message
-    ) {}
 }

--- a/src/main/java/com/team5/catdogeats/global/enums/ResponseCode.java
+++ b/src/main/java/com/team5/catdogeats/global/enums/ResponseCode.java
@@ -1,0 +1,65 @@
+package com.team5.catdogeats.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseCode {
+
+    // === 공통 성공 응답 ===
+    SUCCESS(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다."),
+
+    // === 공통 오류 응답 ===
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 값이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "요청 값의 타입이 올바르지 않습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "요청을 기다리다 서버에서 타임아웃하였습니다."),
+
+    // === 사용자 관련 오류 ===
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    SELLER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "판매자 권한이 필요합니다."),
+    BUYER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "구매자 권한이 필요합니다."),
+
+    // === 판매자 관련 응답 ===
+    SELLER_INFO_SUCCESS(HttpStatus.OK, "판매자 정보 조회 성공"),
+    SELLER_INFO_SAVE_SUCCESS(HttpStatus.OK, "판매자 정보 저장 성공"),
+    SELLER_INFO_NOT_FOUND(HttpStatus.OK, "등록된 판매자 정보가 없습니다."),
+    BUSINESS_NUMBER_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 사업자 등록번호입니다."),
+    INVALID_OPERATING_HOURS(HttpStatus.BAD_REQUEST, "운영 시간 설정이 올바르지 않습니다."),
+    INVALID_CLOSED_DAYS(HttpStatus.BAD_REQUEST, "휴무일 설정이 올바르지 않습니다."),
+
+    // === 상품 관련 응답 ===
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+    PRODUCT_SAVE_SUCCESS(HttpStatus.OK, "상품이 성공적으로 저장되었습니다."),
+    PRODUCT_DELETE_SUCCESS(HttpStatus.OK, "상품이 성공적으로 삭제되었습니다."),
+
+    // === 주문 관련 응답 ===
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+    ORDER_SUCCESS(HttpStatus.OK, "주문이 성공적으로 처리되었습니다."),
+
+    // === 리뷰 관련 응답 ===
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
+    REVIEW_SAVE_SUCCESS(HttpStatus.OK, "리뷰가 성공적으로 저장되었습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 리뷰를 작성했습니다."),
+
+    // === 채팅 관련 응답 ===
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    CHAT_MESSAGE_SUCCESS(HttpStatus.OK, "메시지가 성공적으로 전송되었습니다."),
+
+    // === 알림 관련 응답 ===
+    NOTIFICATION_SUCCESS(HttpStatus.OK, "알림이 성공적으로 전송되었습니다."),
+    NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "알림을 읽음 처리했습니다."),
+
+    // 추가적인 도메인별 에러 코드 정의 가능
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerInfoController.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerInfoController.java
@@ -1,28 +1,23 @@
 package com.team5.catdogeats.users.controller;
 
 import com.team5.catdogeats.global.dto.ApiResponse;
+import com.team5.catdogeats.global.enums.ResponseCode;
 import com.team5.catdogeats.users.domain.dto.SellerInfoRequest;
 import com.team5.catdogeats.users.domain.dto.SellerInfoResponse;
 import com.team5.catdogeats.users.exception.BusinessNumberDuplicateException;
+import com.team5.catdogeats.users.exception.InvalidOperatingHoursException;
 import com.team5.catdogeats.users.exception.SellerAccessDeniedException;
 import com.team5.catdogeats.users.exception.UserNotFoundException;
 import com.team5.catdogeats.users.service.SellerInfoService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -30,16 +25,16 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/v1/sellers")
 @RequiredArgsConstructor
-@Tag(name = "판매자 정보 관리", description = "판매자 정보 조회 및 등록/수정 API (개발 단계 - JWT 구현 전)")
+@Tag(name = "판매자 정보 관리", description = "판매자 정보 조회 및 등록/수정 API")
 public class SellerInfoController {
 
     private final SellerInfoService sellerInfoService;
 
     /**
-     * 판매자 정보 조회 (개발용 - 하드코딩된 사용자 ID 사용)
+     * 판매자 정보 조회
      */
     @Operation(
-            summary = "판매자 정보 조회 (개발용)",
+            summary = "판매자 정보 조회",
             description = """
                     현재 개발 단계에서는 하드코딩된 사용자 ID를 사용합니다.
                     
@@ -48,95 +43,9 @@ public class SellerInfoController {
                     JWT 구현 완료 후에는 토큰에서 사용자 ID를 추출하여 사용합니다.
                     """
     )
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "판매자 정보 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "정보 있음",
-                                            value = """
-                        {
-                          "success": true,
-                          "message": "판매자 정보 조회 성공",
-                          "data": {
-                            "userId": "2ceb807f-586f-4450-b470-d1ece7173749",
-                            "vendorName": "멍멍이네 수제간식",
-                            "vendorProfileImage": "https://example.com/profile.jpg",
-                            "businessNumber": "123-45-67890",
-                            "settlementBank": "국민은행",
-                            "settlementAcc": "123456789012",
-                            "tags": "수제간식,강아지",
-                            "createdAt": "2024-01-15T10:30:00",
-                            "updatedAt": "2024-01-20T14:20:00"
-                          },
-                          "timestamp": "2024-01-20T15:30:00"
-                        }
-                        """
-                                    ),
-                                    @ExampleObject(
-                                            name = "정보 없음",
-                                            value = """
-                        {
-                          "success": true,
-                          "message": "등록된 판매자 정보가 없습니다.",
-                          "data": null,
-                          "timestamp": "2024-01-20T15:30:00"
-                        }
-                        """
-                                    )
-                            }
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 - 하드코딩된 사용자가 판매자 권한이 없는 경우",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "판매자 권한이 필요합니다.",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info"
-                    }
-                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "하드코딩된 사용자를 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "존재하지 않는 사용자입니다.",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info"
-                    }
-                    """
-                            )
-                    )
-            )
-    })
     @GetMapping("/info")
-    public ResponseEntity<ApiResponse<SellerInfoResponse>> getSellerInfo(
-            HttpServletRequest request) {
-
+    public ResponseEntity<ApiResponse<SellerInfoResponse>> getSellerInfo() {
         // TODO: JWT 토큰에서 사용자 ID 추출하는 로직으로 교체 예정
-        // String token = extractTokenFromHeader(request);
-        // UUID userId = jwtTokenProvider.getUserIdFromToken(token);
-
-        // 현재: 하드코딩된 사용자 ID 사용 (개발용)
         UUID tempUserId = UUID.fromString("2ceb807f-586f-4450-b470-d1ece7173749");
         log.info("판매자 정보 조회 요청 - 개발용 하드코딩 ID: {}", tempUserId);
 
@@ -145,33 +54,33 @@ public class SellerInfoController {
 
             if (response == null) {
                 return ResponseEntity.ok(
-                        ApiResponse.success("등록된 판매자 정보가 없습니다.", null)
+                        ApiResponse.success(ResponseCode.SELLER_INFO_NOT_FOUND)
                 );
             }
 
             return ResponseEntity.ok(
-                    ApiResponse.success("판매자 정보 조회 성공", response)
+                    ApiResponse.success(ResponseCode.SELLER_INFO_SUCCESS, response)
             );
 
         } catch (UserNotFoundException e) {
             log.error("사용자를 찾을 수 없음 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.USER_NOT_FOUND.getStatus())
+                    .body(ApiResponse.error(ResponseCode.USER_NOT_FOUND));
 
         } catch (SellerAccessDeniedException e) {
             log.error("판매자 권한 없음 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.SELLER_ACCESS_DENIED.getStatus())
+                    .body(ApiResponse.error(ResponseCode.SELLER_ACCESS_DENIED));
 
         } catch (Exception e) {
             log.error("판매자 정보 조회 중 오류 발생 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.error("서버 오류가 발생했습니다.", request.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                    .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
     }
 
     /**
-     * 판매자 정보 등록/수정 (개발용 - 하드코딩된 사용자 ID 사용)
+     * 판매자 정보 등록/수정
      */
     @Operation(
             summary = "판매자 정보 등록/수정",
@@ -184,207 +93,63 @@ public class SellerInfoController {
                     JWT 구현 완료 후에는 토큰에서 사용자 ID를 추출하여 사용합니다.
                     """
     )
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description = "판매자 정보 등록/수정 요청",
-            required = true,
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = SellerInfoRequest.class),
-                    examples = @ExampleObject(
-                            name = "판매자 정보 예시",
-                            value = """
-                {
-                  "vendorName": "멍멍이네 수제간식",
-                  "vendorProfileImage": "https://example.com/profile.jpg",
-                  "businessNumber": "123-45-67890",
-                  "settlementBank": "국민은행",
-                  "settlementAcc": "123456789012",
-                  "tags": "수제간식,강아지",
-                  "operatingStartTime": "09:00:00",
-                  "operatingEndTime": "18:00:00",
-                  "closedDays": "월요일,화요일"
-                  
-                }
-                """
-                    )
-            )
-    )
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "판매자 정보 저장 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": true,
-                      "message": "판매자 정보 저장 성공",
-                      "data": {
-                        "userId": "2ceb807f-586f-4450-b470-d1ece7173749",
-                        "vendorName": "멍멍이네 수제간식",
-                        "vendorProfileImage": "https://example.com/profile.jpg",
-                        "businessNumber": "123-45-67890",
-                        "settlementBank": "국민은행",
-                        "settlementAcc": "123456789012",
-                        "tags": "수제간식,강아지",
-                        "operatingStartTime": "09:00:00",
-                        "operatingEndTime": "18:00:00",
-                        "closedDays": "월요일,화요일",
-                        "createdAt": "2024-01-15T10:30:00",
-                        "updatedAt": "2024-01-20T14:20:00"
-                      },
-                      "timestamp": "2024-01-20T15:30:00"
-                    }
-                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "입력값 검증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "입력값 검증 실패",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info",
-                      "errors": [
-                        {
-                          "field": "vendorName",
-                          "message": "업체명은 필수 입력 항목입니다."
-                        },
-                        {
-                          "field": "businessNumber",
-                          "message": "사업자 등록번호는 숫자와 하이픈만 입력 가능합니다."
-                        }
-                      ]
-                    }
-                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 - 하드코딩된 사용자가 판매자 권한이 없는 경우",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "판매자 권한이 필요합니다.",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info"
-                    }
-                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "하드코딩된 사용자를 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "존재하지 않는 사용자입니다.",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info"
-                    }
-                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409",
-                    description = "사업자 등록번호 중복",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = """
-                    {
-                      "success": false,
-                      "message": "이미 등록된 사업자 등록번호입니다.",
-                      "data": null,
-                      "timestamp": "2024-01-20T15:30:00",
-                      "path": "/v1/sellers/info"
-                    }
-                    """
-                            )
-                    )
-            )
-    })
     @PatchMapping("/info")
     public ResponseEntity<ApiResponse<SellerInfoResponse>> upsertSellerInfo(
             @Valid @RequestBody SellerInfoRequest request,
-            BindingResult bindingResult,
-            HttpServletRequest httpRequest) {
+            BindingResult bindingResult) {
 
         // TODO: JWT 토큰에서 사용자 ID 추출하는 로직으로 교체 예정
-        // String token = extractTokenFromHeader(httpRequest);
-        // UUID userId = jwtTokenProvider.getUserIdFromToken(token);
-
-        // 현재: 하드코딩된 사용자 ID 사용 (개발용)
         UUID tempUserId = UUID.fromString("2ceb807f-586f-4450-b470-d1ece7173749");
         log.info("판매자 정보 등록/수정 요청 - 개발용 하드코딩 ID: {}, vendorName: {}",
                 tempUserId, request.vendorName());
 
         // 유효성 검증 오류 처리
         if (bindingResult.hasErrors()) {
-            List<ApiResponse.FieldError> fieldErrors = bindingResult.getFieldErrors().stream()
-                    .map(error -> new ApiResponse.FieldError(
-                            error.getField(),
-                            error.getDefaultMessage()
-                    ))
-                    .collect(Collectors.toList());
+            String errorMessage = bindingResult.getFieldErrors().stream()
+                    .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                    .collect(Collectors.joining(", "));
 
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.error("입력값 검증 실패", httpRequest.getRequestURI(), fieldErrors));
+            return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
+                    .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, errorMessage));
         }
 
         try {
             SellerInfoResponse response = sellerInfoService.upsertSellerInfo(tempUserId, request);
 
             return ResponseEntity.ok(
-                    ApiResponse.success("판매자 정보 저장 성공", response)
+                    ApiResponse.success(ResponseCode.SELLER_INFO_SAVE_SUCCESS, response)
             );
 
         } catch (UserNotFoundException e) {
             log.error("사용자를 찾을 수 없음 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(ApiResponse.error(e.getMessage(), httpRequest.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.USER_NOT_FOUND.getStatus())
+                    .body(ApiResponse.error(ResponseCode.USER_NOT_FOUND));
 
         } catch (SellerAccessDeniedException e) {
             log.error("판매자 권한 없음 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(ApiResponse.error(e.getMessage(), httpRequest.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.SELLER_ACCESS_DENIED.getStatus())
+                    .body(ApiResponse.error(ResponseCode.SELLER_ACCESS_DENIED));
 
         } catch (BusinessNumberDuplicateException e) {
             log.error("사업자 등록번호 중복 - userId: {}, businessNumber: {}",
                     tempUserId, request.businessNumber(), e);
-            return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(ApiResponse.error(e.getMessage(), httpRequest.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.BUSINESS_NUMBER_DUPLICATE.getStatus())
+                    .body(ApiResponse.error(ResponseCode.BUSINESS_NUMBER_DUPLICATE));
+
+        } catch (InvalidOperatingHoursException e) {
+            log.error("운영시간 유효성 검증 실패 - userId: {}, error: {}", tempUserId, e.getMessage(), e);
+            return ResponseEntity.status(ResponseCode.INVALID_OPERATING_HOURS.getStatus())
+                    .body(ApiResponse.error(ResponseCode.INVALID_OPERATING_HOURS, e.getMessage()));
 
         } catch (IllegalArgumentException e) {
-            // 운영시간 유효성 검증 오류 처리 추가
-            log.error("운영시간 유효성 검증 실패 - userId: {}, error: {}", tempUserId, e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(ApiResponse.error(e.getMessage(), httpRequest.getRequestURI(), null));
+            log.error("입력값 유효성 검증 실패 - userId: {}, error: {}", tempUserId, e.getMessage(), e);
+            return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
+                    .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
 
         } catch (Exception e) {
             log.error("판매자 정보 저장 중 오류 발생 - userId: {}", tempUserId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.error("서버 오류가 발생했습니다.", httpRequest.getRequestURI(), null));
+            return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                    .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
     }
 

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
@@ -1,13 +1,12 @@
 package com.team5.catdogeats.users.controller;
 
 import com.team5.catdogeats.global.dto.ApiResponse;
+import com.team5.catdogeats.global.enums.ResponseCode;
 import com.team5.catdogeats.users.exception.BusinessNumberDuplicateException;
 import com.team5.catdogeats.users.exception.InvalidOperatingHoursException;
 import com.team5.catdogeats.users.exception.SellerAccessDeniedException;
 import com.team5.catdogeats.users.exception.UserNotFoundException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,53 +19,40 @@ public class SellerInfoExceptionHandler {
      * 사용자 없음 예외 처리
      */
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ApiResponse<Object>> handleUserNotFound(
-            UserNotFoundException e, HttpServletRequest request) {
-
-        log.warn("사용자 없음 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleUserNotFound(UserNotFoundException e) {
+        log.warn("사용자 없음 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.USER_NOT_FOUND.getStatus())
+                .body(ApiResponse.error(ResponseCode.USER_NOT_FOUND));
     }
 
     /**
      * 사업자 등록번호 중복 예외 처리
      */
     @ExceptionHandler(BusinessNumberDuplicateException.class)
-    public ResponseEntity<ApiResponse<Object>> handleBusinessNumberDuplicate(
-            BusinessNumberDuplicateException e, HttpServletRequest request) {
-
-        log.warn("사업자 등록번호 중복 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleBusinessNumberDuplicate(BusinessNumberDuplicateException e) {
+        log.warn("사업자 등록번호 중복 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.BUSINESS_NUMBER_DUPLICATE.getStatus())
+                .body(ApiResponse.error(ResponseCode.BUSINESS_NUMBER_DUPLICATE));
     }
 
     /**
-     *  운영시간 잘못된 입력 예외 처리
+     * 운영시간 잘못된 입력 예외 처리
      */
     @ExceptionHandler(InvalidOperatingHoursException.class)
-    public ResponseEntity<ApiResponse<Object>> handleInvalidOperatingHours(
-            InvalidOperatingHoursException e, HttpServletRequest request) {
-
-        log.warn("운영시간 유효성 검증 실패 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleInvalidOperatingHours(InvalidOperatingHoursException e) {
+        log.warn("운영시간 유효성 검증 실패 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.INVALID_OPERATING_HOURS.getStatus())
+                .body(ApiResponse.error(ResponseCode.INVALID_OPERATING_HOURS, e.getMessage()));
     }
-
 
     /**
      * 커스텀 판매자 접근 권한 없음 예외 처리
      */
     @ExceptionHandler(SellerAccessDeniedException.class)
-    public ResponseEntity<ApiResponse<Object>> handleSellerAccessDenied(
-            SellerAccessDeniedException e, HttpServletRequest request) {
-
-        log.warn("판매자 접근 권한 없음 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleSellerAccessDenied(SellerAccessDeniedException e) {
+        log.warn("판매자 접근 권한 없음 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.SELLER_ACCESS_DENIED.getStatus())
+                .body(ApiResponse.error(ResponseCode.SELLER_ACCESS_DENIED));
     }
 
     /**
@@ -74,38 +60,29 @@ public class SellerInfoExceptionHandler {
      */
     @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
     public ResponseEntity<ApiResponse<Object>> handleSpringAccessDenied(
-            org.springframework.security.access.AccessDeniedException e, HttpServletRequest request) {
-
-        log.warn("Spring Security 접근 권한 없음 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.error("권한이 없습니다. 판매자만 접근 가능합니다.",
-                        request.getRequestURI(), null));
+            org.springframework.security.access.AccessDeniedException e) {
+        log.warn("Spring Security 접근 권한 없음 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.ACCESS_DENIED.getStatus())
+                .body(ApiResponse.error(ResponseCode.ACCESS_DENIED));
     }
 
     /**
      * IllegalArgumentException 처리
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Object>> handleIllegalArgument(
-            IllegalArgumentException e, HttpServletRequest request) {
-
-        log.warn("잘못된 요청 - URI: {}, Message: {}", request.getRequestURI(), e.getMessage());
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage(), request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleIllegalArgument(IllegalArgumentException e) {
+        log.warn("잘못된 요청 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
     }
 
     /**
      * 기타 예상치 못한 예외 처리
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleGeneral(
-            Exception e, HttpServletRequest request) {
-
-        log.error("예상치 못한 오류 - URI: {}", request.getRequestURI(), e);
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류가 발생했습니다.", request.getRequestURI(), null));
+    public ResponseEntity<ApiResponse<Object>> handleGeneral(Exception e) {
+        log.error("예상치 못한 오류", e);
+        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoRequest.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoRequest.java
@@ -1,39 +1,51 @@
 package com.team5.catdogeats.users.domain.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-
 import java.time.LocalTime;
 
+@Schema(description = "판매자 정보 등록/수정 요청 DTO")
 public record SellerInfoRequest(
+
+        @Schema(description = "업체명", example = "멍멍이네 수제간식", required = true)
         @NotBlank(message = "업체명은 필수 입력 항목입니다.")
         @Size(max = 100, message = "업체명은 최대 100자까지 입력 가능합니다.")
         String vendorName,
 
+        @Schema(description = "업체 프로필 이미지 URL", example = "https://example.com/profile.jpg", required = true)
         @NotBlank(message = "업체 프로필 이미지는 필수 입력 항목입니다.")
         @Size(max = 255, message = "이미지 URL은 최대 255자까지 입력 가능합니다.")
         String vendorProfileImage,
 
+        @Schema(description = "사업자 등록번호", example = "123-45-67890", required = true)
         @NotBlank(message = "사업자 등록번호는 필수 입력 항목입니다.")
         @Size(max = 20, message = "사업자 등록번호는 최대 20자까지 입력 가능합니다.")
         @Pattern(regexp = "^[0-9\\-]+$", message = "사업자 등록번호는 숫자와 하이픈만 입력 가능합니다.")
         String businessNumber,
 
+        @Schema(description = "정산 은행명", example = "국민은행")
         @Size(max = 50, message = "은행명은 최대 50자까지 입력 가능합니다.")
         String settlementBank,
 
+        @Schema(description = "정산 계좌번호", example = "123456789012")
         @Size(max = 30, message = "계좌번호는 최대 30자까지 입력 가능합니다.")
         String settlementAcc,
 
+        @Schema(description = "태그 (쉼표로 구분)", example = "수제간식,강아지")
         @Size(max = 36, message = "태그는 최대 36자까지 입력 가능합니다.")
         String tags,
 
+        @Schema(description = "운영 시작 시간", example = "09:00:00")
         LocalTime operatingStartTime,
 
+        @Schema(description = "운영 종료 시간", example = "18:00:00")
         LocalTime operatingEndTime,
 
+        @Schema(description = "휴무일 (쉼표로 구분)", example = "월요일,화요일")
         @Size(max = 20, message = "휴무일은 최대 20자까지 입력 가능합니다.")
         String closedDays
+
 ) {}

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoResponse.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoResponse.java
@@ -1,23 +1,50 @@
 package com.team5.catdogeats.users.domain.dto;
 
 import com.team5.catdogeats.users.domain.mapping.Sellers;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+@Schema(description = "판매자 정보 응답 DTO")
 public record SellerInfoResponse(
+
+        @Schema(description = "사용자 ID", example = "2ceb807f-586f-4450-b470-d1ece7173749")
         String userId,
+
+        @Schema(description = "업체명", example = "멍멍이네 수제간식")
         String vendorName,
+
+        @Schema(description = "업체 프로필 이미지 URL", example = "https://example.com/profile.jpg")
         String vendorProfileImage,
+
+        @Schema(description = "사업자 등록번호", example = "123-45-67890")
         String businessNumber,
+
+        @Schema(description = "정산 은행명", example = "국민은행")
         String settlementBank,
+
+        @Schema(description = "정산 계좌번호", example = "123456789012")
         String settlementAcc,
+
+        @Schema(description = "태그", example = "수제간식,강아지")
         String tags,
+
+        @Schema(description = "운영 시작 시간", example = "09:00:00")
         LocalTime operatingStartTime,
+
+        @Schema(description = "운영 종료 시간", example = "18:00:00")
         LocalTime operatingEndTime,
+
+        @Schema(description = "휴무일", example = "월요일,화요일")
         String closedDays,
+
+        @Schema(description = "생성일시", example = "2024-01-15T10:30:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "수정일시", example = "2024-01-20T14:20:00")
         LocalDateTime updatedAt
+
 ) {
     public static SellerInfoResponse from(Sellers seller) {
         if (seller == null) {


### PR DESCRIPTION
📌 TODO: Swagger 문서 개선을 위한 DTO 및 ResponseApi 리팩토링

## ✅ 작업 내용  
- [ ] DTO 클래스에 `@Schema(example = "...")` 어노테이션 추가하여 필드별 예제 값 설정
- [ ] 컨트롤러에서 직접 JSON 하드코딩하던 `@ExampleObject` 제거 또는 최소화
- [ ] 공통 응답 메시지 및 예시 JSON은 `ResponseCode` + `ApiResponse` 조합으로 통일
- [ ] ApiReponse 에서 localDateTime -> ZoneDateTime 으로 수정 


## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (예: #23) -->
- 이슈 번호 : #19 



## 📝 참고 사항
<!-- 리뷰어가 참고할 만한 내용을 자유롭게 작성해주세요 -->
- 

---

## 🙏 리뷰 요청 사항
<!-- 특별히 리뷰어에게 받고 싶은 피드백이 있다면 작성해주세요 -->