### PR TITLE
[refactor] 펫 정보 관련 api 로그인 연동

### DIFF
--- a/src/main/java/com/team5/catdogeats/pets/controller/PetController.java
+++ b/src/main/java/com/team5/catdogeats/pets/controller/PetController.java
@@ -1,5 +1,6 @@
 package com.team5.catdogeats.pets.controller;
 
+import com.team5.catdogeats.auth.dto.UserPrincipal;
 import com.team5.catdogeats.global.dto.ApiResponse;
 import com.team5.catdogeats.global.enums.ResponseCode;
 import com.team5.catdogeats.pets.domain.dto.*;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -27,9 +29,9 @@ public class PetController {
 
     @Operation(summary = "펫 등록", description = "새로운 펫 정보를 등록합니다.")
     @PostMapping("/pet")
-    public ResponseEntity<ApiResponse<Void>> registerPet(@RequestBody @Valid @Parameter(description = "등록할 펫 정보", required = true) PetCreateRequestDto dto) {
+    public ResponseEntity<ApiResponse<Void>> registerPet(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody @Valid @Parameter(description = "등록할 펫 정보", required = true) PetCreateRequestDto dto) {
         try {
-            UUID petId = petService.registerPet(dto);
+            UUID petId = petService.registerPet(userPrincipal, dto);
             return ResponseEntity
                     .created(URI.create("/v1/buyers/pet/" + petId))
                     .body(ApiResponse.success(ResponseCode.CREATED));
@@ -46,9 +48,9 @@ public class PetController {
 
     @Operation(summary = "내 펫 목록 조회", description = "로그인한 사용자의 펫 목록을 조회합니다.")
     @GetMapping("/pet")
-    public ResponseEntity<ApiResponse<List<PetResponseDto>>> getMyPets() {
+    public ResponseEntity<ApiResponse<List<PetResponseDto>>> getMyPets(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         try {
-            List<PetResponseDto> pets = petService.getMyPets();
+            List<PetResponseDto> pets = petService.getMyPets(userPrincipal);
             return ResponseEntity.ok(ApiResponse.success(ResponseCode.SUCCESS, pets));
         } catch (NoSuchElementException e) {
             return ResponseEntity

--- a/src/main/java/com/team5/catdogeats/pets/service/PetService.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/PetService.java
@@ -1,5 +1,6 @@
 package com.team5.catdogeats.pets.service;
 
+import com.team5.catdogeats.auth.dto.UserPrincipal;
 import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
 import com.team5.catdogeats.pets.domain.dto.PetDeleteRequestDto;
 import com.team5.catdogeats.pets.domain.dto.PetResponseDto;
@@ -9,8 +10,8 @@ import java.util.List;
 import java.util.UUID;
 
 public interface PetService {
-    UUID registerPet(PetCreateRequestDto dto);
-    List<PetResponseDto> getMyPets();
+    UUID registerPet(UserPrincipal userPrincipal, PetCreateRequestDto dto);
+    List<PetResponseDto> getMyPets(UserPrincipal userPrincipal);
     void updatePet(PetUpdateRequestDto dto);
     void deletePet(PetDeleteRequestDto dto);
 }

--- a/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team5.catdogeats.pets.service.impl;
 
+import com.team5.catdogeats.auth.dto.UserPrincipal;
 import com.team5.catdogeats.pets.domain.Pets;
 import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
 import com.team5.catdogeats.pets.domain.dto.PetDeleteRequestDto;
@@ -7,6 +8,7 @@ import com.team5.catdogeats.pets.domain.dto.PetResponseDto;
 import com.team5.catdogeats.pets.domain.dto.PetUpdateRequestDto;
 import com.team5.catdogeats.pets.repository.PetRepository;
 import com.team5.catdogeats.pets.service.PetService;
+import com.team5.catdogeats.users.domain.dto.BuyerDTO;
 import com.team5.catdogeats.users.domain.mapping.Buyers;
 import com.team5.catdogeats.users.repository.BuyerRepository;
 import jakarta.transaction.Transactional;
@@ -25,22 +27,28 @@ public class PetServiceImpl implements PetService {
     private final BuyerRepository buyerRepository;
 
     @Override
-    public UUID registerPet(PetCreateRequestDto dto) {
-//      TODO: UUID userId = SecurityUtil.getCurrentUserId();
-        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-        Buyers buyer = buyerRepository.findById(userId)
+    public UUID registerPet(UserPrincipal userPrincipal, PetCreateRequestDto dto) {
+        BuyerDTO buyerDTO = buyerRepository.findOnlyBuyerByProviderAndProviderId(userPrincipal.provider(), userPrincipal.providerId())
                 .orElseThrow(() -> new NoSuchElementException("해당 유저 정보를 찾을 수 없습니다."));
+
+        Buyers buyer = Buyers.builder()
+                .userId(buyerDTO.userId())
+                .nameMaskingStatus(buyerDTO.nameMaskingStatus())
+                .build();
 
         Pets pet = Pets.fromDto(dto, buyer);
         return petRepository.save(pet).getId();
     }
 
     @Override
-    public List<PetResponseDto> getMyPets() {
-//      TODO:  UUID userId = SecurityUtil.getCurrentUserId();
-        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-        Buyers buyer = buyerRepository.findById(userId)
+    public List<PetResponseDto> getMyPets(UserPrincipal userPrincipal) {
+        BuyerDTO buyerDTO = buyerRepository.findOnlyBuyerByProviderAndProviderId(userPrincipal.provider(), userPrincipal.providerId())
                 .orElseThrow(() -> new NoSuchElementException("해당 유저 정보를 찾을 수 없습니다."));
+
+        Buyers buyer = Buyers.builder()
+                .userId(buyerDTO.userId())
+                .nameMaskingStatus(buyerDTO.nameMaskingStatus())
+                .build();
 
         return petRepository.findByBuyer(buyer)
                 .stream()


### PR DESCRIPTION
## 📌 PR 제목
refactor: 펫 정보 관련 api 로그인 연동

---

## 📄 개요
하드 코딩으로 buyerId 받아오던 부분 로그인 연동 후 쿠키에서 buyerId 받아오기로 수정
- 

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [x] 기능 구현
- [ ] UI/UX 수정
- [ ] API 연동
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서 작성

---

## 📃 작업 세부 내용
@AuthenticationalPrinciapl UserPrinciapl userPrinciapl 통해서 쿠키의 정보 받아옴
해당 parameter 통해서 로그인 연동 완료

---

## 🔍 관련 이슈
#27 
- 

---

## 📝 참고 사항

- 

---

## 🙏 리뷰 요청 사항
- 
