### PR TITLE
[refactor] pet 정보 조회 페이징 처리 추가

### DIFF
--- a/src/main/java/com/team5/catdogeats/pets/domain/dto/PageResponseDto.java
+++ b/src/main/java/com/team5/catdogeats/pets/domain/dto/PageResponseDto.java
@@ -1,0 +1,13 @@
+package com.team5.catdogeats.pets.domain.dto;
+
+import java.util.List;
+
+public record PageResponseDto<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last // 현재 페이지가 마지막 페이지인가?
+) {
+}

--- a/src/main/java/com/team5/catdogeats/pets/repository/PetRepository.java
+++ b/src/main/java/com/team5/catdogeats/pets/repository/PetRepository.java
@@ -2,13 +2,14 @@ package com.team5.catdogeats.pets.repository;
 
 import com.team5.catdogeats.pets.domain.Pets;
 import com.team5.catdogeats.users.domain.mapping.Buyers;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pets, String> {
-    List<Pets> findByBuyer(Buyers buyer);
+    Page<Pets> findByBuyer(Buyers buyer, Pageable pageable);
 
     Optional<Pets> findById(String id);
 

--- a/src/main/java/com/team5/catdogeats/pets/service/PetService.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/PetService.java
@@ -5,12 +5,11 @@ import com.team5.catdogeats.pets.domain.dto.PetCreateRequestDto;
 import com.team5.catdogeats.pets.domain.dto.PetDeleteRequestDto;
 import com.team5.catdogeats.pets.domain.dto.PetResponseDto;
 import com.team5.catdogeats.pets.domain.dto.PetUpdateRequestDto;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface PetService {
     String registerPet(UserPrincipal userPrincipal, PetCreateRequestDto dto);
-    List<PetResponseDto> getMyPets(UserPrincipal userPrincipal);
+    Page<PetResponseDto> getMyPets(UserPrincipal userPrincipal, int page, int size);
     void updatePet(PetUpdateRequestDto dto);
     void deletePet(PetDeleteRequestDto dto);
 }

--- a/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/pets/service/impl/PetServiceImpl.java
@@ -13,9 +13,11 @@ import com.team5.catdogeats.users.domain.dto.BuyerDTO;
 import com.team5.catdogeats.users.domain.mapping.Buyers;
 import com.team5.catdogeats.users.repository.BuyerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -40,7 +42,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
-    public List<PetResponseDto> getMyPets(UserPrincipal userPrincipal) {
+    public Page<PetResponseDto> getMyPets(UserPrincipal userPrincipal, int page, int size) {
         BuyerDTO buyerDTO = buyerRepository.findOnlyBuyerByProviderAndProviderId(userPrincipal.provider(), userPrincipal.providerId())
                 .orElseThrow(() -> new NoSuchElementException("해당 유저 정보를 찾을 수 없습니다."));
 
@@ -49,10 +51,10 @@ public class PetServiceImpl implements PetService {
                 .nameMaskingStatus(buyerDTO.nameMaskingStatus())
                 .build();
 
-        return petRepository.findByBuyer(buyer)
-                .stream()
-                .map(PetResponseDto::fromEntity)
-                .toList();
+        Pageable pageable = PageRequest.of(page, size);
+
+        return petRepository.findByBuyer(buyer, pageable)
+                .map(PetResponseDto::fromEntity);
     }
 
     @JpaTransactional


### PR DESCRIPTION
## 📌 PR 제목
refactor: 펫 정보 조회 페이징 처리 추가

---

## 📄 개요
펫 정보 조회 페이징 처리 추가
- 

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [x] 기능 구현
- [ ] UI/UX 수정
- [ ] API 연동
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [x] 문서 작성

---

## 📃 작업 세부 내용

PageResponseDto 정의하여 페이징 처리된 응답 결과 구조 정의
size default값 4로 지정 (페이지당 4개 정보 보이게 함)

---

## 🔍 관련 이슈
#46 
- 

---

## 📝 참고 사항

- 

---

## 🙏 리뷰 요청 사항

- 
