### PR TITLE
[feat] 회원기능 - 판매자 브랜드 이미지 업로드 (s3) 

### DIFF
--- a/src/main/java/com/team5/catdogeats/storage/util/ImageValidationUtil.java
+++ b/src/main/java/com/team5/catdogeats/storage/util/ImageValidationUtil.java
@@ -1,0 +1,188 @@
+package com.team5.catdogeats.storage.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 이미지 파일 검증을 위한 공용 유틸리티 클래스
+ * Storage 도메인에서 사용하는 이미지 검증 로직을 통합 관리
+ */
+@Slf4j
+@Component
+public class ImageValidationUtil {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final int MAX_FILENAME_LENGTH = 255;
+
+    /**
+     * 통합 이미지 파일 검증
+     * - 기본 속성 검사 (크기, NULL 등)
+     * - 실제 파일 내용 검증 (Magic Number)
+     * - 보안 강화된 단일 검증 메서드
+     *
+     * @param imageFile 검증할 이미지 파일
+     * @throws IllegalArgumentException 검증 실패 시
+     */
+    public void validateImageFile(MultipartFile imageFile) {
+        // 기본 검사
+        validateBasicProperties(imageFile);
+
+        // MIME Type 검증
+        validateMimeType(imageFile);
+
+        // 파일명 보안 검증
+        validateFileName(imageFile.getOriginalFilename());
+
+        // 스크립트 공격 방지
+        validateNoScriptContent(imageFile);
+
+        // 실제 파일 내용 검증
+        validateFileSignature(imageFile);
+
+        log.debug("이미지 파일 검증 완료 - fileName: {}, size: {}",
+                imageFile.getOriginalFilename(), imageFile.getSize());
+    }
+
+    /**
+     * 기본 속성 검증
+     */
+    private void validateBasicProperties(MultipartFile imageFile) {
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new IllegalArgumentException("이미지 파일이 비어있습니다.");
+        }
+
+        if (imageFile.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * MIME Type 검증
+     */
+    private void validateMimeType(MultipartFile file) {
+        String contentType = file.getContentType();
+
+        if (contentType == null) {
+            throw new IllegalArgumentException("파일의 Content-Type을 확인할 수 없습니다.");
+        }
+
+        if (!contentType.matches("^image/(jpeg|jpg|png|webp)$")) {
+            throw new IllegalArgumentException(
+                    String.format("허용되지 않은 MIME 타입입니다: %s", contentType));
+        }
+    }
+
+    /**
+     * 파일명 보안 검증
+     */
+    private void validateFileName(String fileName) {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            throw new IllegalArgumentException("파일명이 비어있습니다.");
+        }
+
+        if (fileName.length() > MAX_FILENAME_LENGTH) {
+            throw new IllegalArgumentException("파일명이 너무 깁니다. (최대 255자)");
+        }
+
+        // 경로 순회 공격 방지
+        if (fileName.contains("..") || fileName.contains("./") || fileName.contains(".\\")) {
+            throw new IllegalArgumentException("파일명에 상대경로가 포함될 수 없습니다.");
+        }
+
+        // 위험한 확장자 차단
+        if (fileName.toLowerCase().matches(".*\\.(js|html|htm|php|jsp|asp|exe|bat|cmd).*")) {
+            throw new IllegalArgumentException("실행 가능한 파일 확장자는 업로드할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 스크립트 공격 방지
+     */
+    private void validateNoScriptContent(MultipartFile file) {
+        try (InputStream is = file.getInputStream()) {
+            byte[] buffer = new byte[2048];
+            int bytesRead = is.read(buffer);
+
+            if (bytesRead > 0) {
+                String content = new String(buffer, 0, bytesRead, StandardCharsets.UTF_8).toLowerCase();
+
+                String[] dangerousPatterns = {
+                        "<script", "javascript:", "onload=", "onerror=",
+                        "onclick=", "eval(", "document.", "alert("
+                };
+
+                for (String pattern : dangerousPatterns) {
+                    if (content.contains(pattern)) {
+                        throw new IllegalArgumentException(
+                                "보안상 위험한 스크립트가 포함된 파일은 업로드할 수 없습니다.");
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("파일 내용 검증 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * 파일 시그니처 검증 (Magic Number)
+     * - JPEG, PNG, WebP 실제 파일 형식 확인
+     * - Content-Type 조작 공격 방어
+     */
+    private void validateFileSignature(MultipartFile file) {
+        try (InputStream is = file.getInputStream()) {
+            byte[] header = new byte[12]; // WebP 확인을 위해 12바이트
+            int bytesRead = is.read(header);
+
+            if (bytesRead < 4) {
+                throw new IllegalArgumentException("파일 형식을 확인할 수 없습니다.");
+            }
+
+            // JPEG: FF D8 FF
+            if (header[0] == (byte) 0xFF && header[1] == (byte) 0xD8 && header[2] == (byte) 0xFF) {
+                return;
+            }
+
+            // PNG: 89 50 4E 47
+            if (header[0] == (byte) 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47) {
+                return;
+            }
+
+            // WebP: RIFF....WEBP
+            if (header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
+                    header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50) {
+                return;
+            }
+
+            throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다. (JPEG, PNG, WebP만 지원)");
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("파일 형식 검증 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * 안전한 파일 확장자 추출
+     */
+    public String getFileExtension(String fileName) {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            return "jpg";
+        }
+
+        String safeName = fileName.replaceAll("[^a-zA-Z0-9._-]", "");
+        int lastDotIndex = safeName.lastIndexOf('.');
+
+        if (lastDotIndex != -1 && lastDotIndex < safeName.length() - 1) {
+            String ext = safeName.substring(lastDotIndex + 1).toLowerCase();
+            if (ext.matches("^(jpg|jpeg|png|webp)$")) {
+                return ext;
+            }
+        }
+
+        return "jpg";
+    }
+}

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageController.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageController.java
@@ -1,0 +1,56 @@
+package com.team5.catdogeats.users.controller;
+
+import com.team5.catdogeats.auth.dto.UserPrincipal;
+import com.team5.catdogeats.global.dto.ApiResponse;
+import com.team5.catdogeats.global.enums.ResponseCode;
+import com.team5.catdogeats.users.domain.dto.SellerBrandImageResponseDTO;
+import com.team5.catdogeats.users.service.SellerBrandImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/sellers")
+@RequiredArgsConstructor
+@Tag(name = "판매자 브랜드 이미지 관리", description = "판매자 브랜드 이미지 업로드 및 수정 API")
+public class SellerBrandImageController {
+
+    private final SellerBrandImageService sellerBrandImageService;
+
+    @Operation(
+            summary = "판매자 브랜드 이미지 업로드/수정",
+            description = """
+                    판매자의 브랜드 이미지를 업로드하거나 수정합니다.
+                    판매자 권한(ROLE_SELLER)이 필요합니다.
+                    파일 크기: 최대 10MB, 지원 형식: JPEG, PNG, JPG, WebP
+                    """
+    )
+    @PatchMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<SellerBrandImageResponseDTO>> uploadBrandImage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @Parameter(description = "업로드할 브랜드 이미지 파일")
+            @RequestPart("image") MultipartFile imageFile) {
+
+        log.info("판매자 브랜드 이미지 업로드 요청 - provider: {}, providerId: {}, fileName: {}",
+                userPrincipal.provider(), userPrincipal.providerId(),
+                imageFile != null ? imageFile.getOriginalFilename() : "null");
+
+        SellerBrandImageResponseDTO response = sellerBrandImageService.uploadBrandImage(userPrincipal, imageFile);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(ResponseCode.SELLER_INFO_SAVE_SUCCESS, response)
+        );
+    }
+}

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageController.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageController.java
@@ -13,10 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -51,6 +48,29 @@ public class SellerBrandImageController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(ResponseCode.SELLER_INFO_SAVE_SUCCESS, response)
+        );
+    }
+
+
+    @Operation(
+            summary = "판매자 브랜드 이미지 삭제",
+            description = """
+                판매자의 브랜드 이미지를 삭제합니다.
+                판매자 권한(ROLE_SELLER)이 필요합니다.
+                S3에서 이미지 파일을 삭제하고 DB의 이미지 URL을 null로 설정합니다.
+                """
+    )
+    @DeleteMapping("/image")
+    public ResponseEntity<ApiResponse<SellerBrandImageResponseDTO>> deleteBrandImage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        log.info("판매자 브랜드 이미지 삭제 요청 - provider: {}, providerId: {}",
+                userPrincipal.provider(), userPrincipal.providerId());
+
+        SellerBrandImageResponseDTO response = sellerBrandImageService.deleteBrandImage(userPrincipal);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(ResponseCode.SUCCESS, response)
         );
     }
 }

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageExceptionHandler.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerBrandImageExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.team5.catdogeats.users.controller;
+
+import com.team5.catdogeats.global.dto.ApiResponse;
+import com.team5.catdogeats.global.enums.ResponseCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * 판매자 브랜드 이미지 관련 예외 처리 핸들러
+ * SellerBrandImageController에서 발생하는 예외를 처리
+ */
+@Slf4j
+@RestControllerAdvice(assignableTypes = SellerBrandImageController.class)
+public class SellerBrandImageExceptionHandler {
+
+    /**
+     * 사용자 또는 판매자 정보를 찾을 수 없는 경우
+     * Service의 findUserByPrincipal(), findSellerByUserId()에서 발생
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handleEntityNotFound(EntityNotFoundException e) {
+        log.warn("사용자/판매자 정보 조회 실패 - Message: {}", e.getMessage());
+
+        return ResponseEntity.status(ResponseCode.USER_NOT_FOUND.getStatus())
+                .body(ApiResponse.error(ResponseCode.USER_NOT_FOUND, e.getMessage()));
+    }
+
+    /**
+     * 파일 업로드 관련 파라미터 오류 처리
+     * Service의 validateImageFile()에서 발생하는 IllegalArgumentException
+     * - 파일이 null이거나 비어있음
+     * - 파일크기 검증
+     * - 지원하지 않는 파일 형식
+     * - Content-Type 오류 등
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Object>> handleIllegalArgument(IllegalArgumentException e) {
+        log.warn("파일 업로드 파라미터 오류 - Message: {}", e.getMessage());
+
+        return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
+    }
+
+    /**
+     * 런타임 예외 처리
+     * Service의 uploadNewImage(), deleteBrandImage()에서 발생
+     * - "이미지 업로드 중 오류가 발생했습니다."
+     * - "이미지 업로드 실패"
+     * - "브랜드 이미지 삭제에 실패했습니다."
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<Object>> handleRuntimeException(RuntimeException e) {
+        log.error("브랜드 이미지 처리 중 런타임 오류 - Message: {}", e.getMessage(), e);
+
+        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage()));
+    }
+
+
+    /**
+     * 기타 예상치 못한 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleGeneral(Exception e) {
+        log.error("브랜드 이미지 처리 중 예상치 못한 오류", e);
+
+        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.persistence.EntityNotFoundException;
-import org.springframework.web.multipart.MaxUploadSizeExceededException;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -92,35 +90,6 @@ public class SellerInfoExceptionHandler {
         return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
                 .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
     }
-
-
-
-
-    /**
-     * 이미지 업로드 크기 초과 예외 처리
-     */
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ApiResponse<Object>> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
-        log.warn("파일 업로드 크기 초과 - Message: {}", e.getMessage());
-        return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
-                .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, "이미지 크기가 너무 큽니다. 최대 10MB까지 업로드 가능합니다."));
-    }
-
-    /**
-     * 이미지 업로드 관련 I/O 예외 처리
-     */
-    @ExceptionHandler(java.io.IOException.class)
-    public ResponseEntity<ApiResponse<Object>> handleIOException(java.io.IOException e) {
-        log.error("이미지 처리 중 I/O 오류", e);
-        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
-                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "이미지 처리 중 오류가 발생했습니다."));
-    }
-
-
-
-
-
-
 
     /**
      * 기타 예상치 못한 예외 처리

--- a/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
+++ b/src/main/java/com/team5/catdogeats/users/controller/SellerInfoExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -90,6 +92,35 @@ public class SellerInfoExceptionHandler {
         return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
                 .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
     }
+
+
+
+
+    /**
+     * 이미지 업로드 크기 초과 예외 처리
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
+        log.warn("파일 업로드 크기 초과 - Message: {}", e.getMessage());
+        return ResponseEntity.status(ResponseCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, "이미지 크기가 너무 큽니다. 최대 10MB까지 업로드 가능합니다."));
+    }
+
+    /**
+     * 이미지 업로드 관련 I/O 예외 처리
+     */
+    @ExceptionHandler(java.io.IOException.class)
+    public ResponseEntity<ApiResponse<Object>> handleIOException(java.io.IOException e) {
+        log.error("이미지 처리 중 I/O 오류", e);
+        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "이미지 처리 중 오류가 발생했습니다."));
+    }
+
+
+
+
+
+
 
     /**
      * 기타 예상치 못한 예외 처리

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerBrandImageResponseDTO.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerBrandImageResponseDTO.java
@@ -2,6 +2,8 @@ package com.team5.catdogeats.users.domain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.ZonedDateTime;
+
 @Schema(description = "판매자 브랜드 이미지 업로드 응답 DTO")
 public record SellerBrandImageResponseDTO(
         @Schema(description = "사용자 ID", example = "2ceb807f-586f-4450-b470-d1ece7173749")
@@ -14,14 +16,14 @@ public record SellerBrandImageResponseDTO(
         String vendorProfileImage,
 
         @Schema(description = "이미지 업로드 시간", example = "2024-01-20T14:20:00")
-        java.time.LocalDateTime updatedAt
+        ZonedDateTime updatedAt
 ) {
     public static SellerBrandImageResponseDTO from(com.team5.catdogeats.users.domain.mapping.Sellers seller) {
         return new SellerBrandImageResponseDTO(
                 seller.getUserId(),
                 seller.getVendorName(),
                 seller.getVendorProfileImage(),
-                seller.getUpdatedAt() != null ? seller.getUpdatedAt().toLocalDateTime() : null
+                seller.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerBrandImageResponseDTO.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerBrandImageResponseDTO.java
@@ -1,0 +1,27 @@
+package com.team5.catdogeats.users.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "판매자 브랜드 이미지 업로드 응답 DTO")
+public record SellerBrandImageResponseDTO(
+        @Schema(description = "사용자 ID", example = "2ceb807f-586f-4450-b470-d1ece7173749")
+        String userId,
+
+        @Schema(description = "업체명", example = "멍멍이네 수제간식")
+        String vendorName,
+
+        @Schema(description = "업데이트된 브랜드 이미지 URL", example = "https://cdn.example.com/images/brand_image_123.jpg")
+        String vendorProfileImage,
+
+        @Schema(description = "이미지 업로드 시간", example = "2024-01-20T14:20:00")
+        java.time.LocalDateTime updatedAt
+) {
+    public static SellerBrandImageResponseDTO from(com.team5.catdogeats.users.domain.mapping.Sellers seller) {
+        return new SellerBrandImageResponseDTO(
+                seller.getUserId(),
+                seller.getVendorName(),
+                seller.getVendorProfileImage(),
+                seller.getUpdatedAt() != null ? seller.getUpdatedAt().toLocalDateTime() : null
+        );
+    }
+}

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoRequestDTO.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoRequestDTO.java
@@ -15,10 +15,6 @@ public record SellerInfoRequestDTO(
         String vendorName,
 
 
-        @Schema(description = "업체 프로필 이미지 URL", example = "https://example.com/profile.jpg" )
-        @Size(max = 255, message = "이미지 URL은 최대 255자까지 입력 가능합니다.")
-        String vendorProfileImage,
-
         @Schema(description = "사업자 등록번호", example = "123-45-67890", required = true)
         @Size(max = 20, message = "사업자 등록번호는 최대 20자까지 입력 가능합니다.")
         @Pattern(regexp = "^[0-9\\-]+$", message = "사업자 등록번호는 숫자와 하이픈만 입력 가능합니다.")

--- a/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoResponseDTO.java
+++ b/src/main/java/com/team5/catdogeats/users/domain/dto/SellerInfoResponseDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 
 @Schema(description = "판매자 정보 응답 DTO")
 public record SellerInfoResponseDTO(
@@ -40,10 +41,10 @@ public record SellerInfoResponseDTO(
         String closedDays,
 
         @Schema(description = "생성일시", example = "2024-01-15T10:30:00")
-        LocalDateTime createdAt,
+        ZonedDateTime createdAt,
 
         @Schema(description = "수정일시", example = "2024-01-20T14:20:00")
-        LocalDateTime updatedAt
+        ZonedDateTime updatedAt
 
 ) {
     public static SellerInfoResponseDTO from(Sellers seller) {
@@ -62,8 +63,8 @@ public record SellerInfoResponseDTO(
                 seller.getOperatingStartTime(),
                 seller.getOperatingEndTime(),
                 seller.getClosedDays(),
-                seller.getCreatedAt() != null ? seller.getCreatedAt().toLocalDateTime() : null,
-                seller.getUpdatedAt() != null ? seller.getUpdatedAt().toLocalDateTime() : null
+                seller.getCreatedAt(),
+                seller.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/team5/catdogeats/users/repository/SellersRepository.java
+++ b/src/main/java/com/team5/catdogeats/users/repository/SellersRepository.java
@@ -3,6 +3,7 @@ package com.team5.catdogeats.users.repository;
 import com.team5.catdogeats.users.domain.dto.SellerDTO;
 import com.team5.catdogeats.users.domain.mapping.Sellers;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,6 +26,14 @@ public interface SellersRepository extends JpaRepository<Sellers, String> {
      * 상점명으로 판매자 정보 조회
      */
     Optional<Sellers> findByVendorName(String vendorName);
+
+
+    /**
+     * 브랜드 이미지 삭제 (null로 설정)
+     */
+    @Modifying
+    @Query("UPDATE Sellers s SET s.vendorProfileImage = NULL WHERE s.userId = :userId")
+    int deleteVendorProfileImage(@Param("userId") String userId);
 
 
     @Query("""

--- a/src/main/java/com/team5/catdogeats/users/service/SellerBrandImageService.java
+++ b/src/main/java/com/team5/catdogeats/users/service/SellerBrandImageService.java
@@ -1,0 +1,12 @@
+package com.team5.catdogeats.users.service;
+
+import com.team5.catdogeats.auth.dto.UserPrincipal;
+import com.team5.catdogeats.users.domain.dto.SellerBrandImageResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface SellerBrandImageService {
+    /**
+     * 판매자 브랜드 이미지 업로드/수정
+     */
+    SellerBrandImageResponseDTO uploadBrandImage(UserPrincipal userPrincipal, MultipartFile imageFile);
+}

--- a/src/main/java/com/team5/catdogeats/users/service/SellerBrandImageService.java
+++ b/src/main/java/com/team5/catdogeats/users/service/SellerBrandImageService.java
@@ -9,4 +9,9 @@ public interface SellerBrandImageService {
      * 판매자 브랜드 이미지 업로드/수정
      */
     SellerBrandImageResponseDTO uploadBrandImage(UserPrincipal userPrincipal, MultipartFile imageFile);
+
+    /**
+     * 판매자 브랜드 이미지 삭제
+     */
+    SellerBrandImageResponseDTO deleteBrandImage(UserPrincipal userPrincipal);
 }

--- a/src/main/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImpl.java
@@ -30,11 +30,11 @@ public class SellerBrandImageServiceImpl implements SellerBrandImageService {
     @Override
     @JpaTransactional
     public SellerBrandImageResponseDTO uploadBrandImage(UserPrincipal userPrincipal, MultipartFile imageFile) {
-        log.info("판매자 브랜드 이미지 업로드 요청 - provider: {}, providerId: {}, fileName: {}",
-                userPrincipal.provider(), userPrincipal.providerId(), imageFile.getOriginalFilename());
-
         // 1. 이미지 파일 유효성 검증
         validateImageFile(imageFile);
+
+        log.info("판매자 브랜드 이미지 업로드 요청 - provider: {}, providerId: {}, fileName: {}",
+                userPrincipal.provider(), userPrincipal.providerId(), imageFile.getOriginalFilename());
 
         // 2. 사용자 조회
         Users user = findUserByPrincipal(userPrincipal);
@@ -223,9 +223,14 @@ public class SellerBrandImageServiceImpl implements SellerBrandImageService {
         String extension = getFileExtension(originalFileName);
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
-        // userId의 처음 8자리만 사용 (너무 길어지는 것 방지)
-        String shortUserId = userId.length() > 8 ? userId.substring(0, 8) : userId;
+        String cleanUserId = userId;
+        if (userId.startsWith("user-uuid-")) {
+            cleanUserId = userId.substring("user-uuid-".length());
+        }
 
+        String shortUserId = cleanUserId.length() > 8 ? cleanUserId.substring(0, 8) : cleanUserId;
+
+       // 처음 8자리만 사용 (너무 길어지는 것 방지)
         return String.format("brand_%s_%s.%s", shortUserId, uuid, extension);
     }
 

--- a/src/main/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImpl.java
@@ -1,0 +1,215 @@
+package com.team5.catdogeats.users.service.impl;
+
+import com.team5.catdogeats.auth.dto.UserPrincipal;
+import com.team5.catdogeats.global.config.JpaTransactional;
+import com.team5.catdogeats.storage.service.ObjectStorageService;
+import com.team5.catdogeats.users.domain.Users;
+import com.team5.catdogeats.users.domain.dto.SellerBrandImageResponseDTO;
+import com.team5.catdogeats.users.domain.mapping.Sellers;
+import com.team5.catdogeats.users.repository.SellersRepository;
+import com.team5.catdogeats.users.repository.UserRepository;
+import com.team5.catdogeats.users.service.SellerBrandImageService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SellerBrandImageServiceImpl implements SellerBrandImageService {
+
+    private final SellersRepository sellersRepository;
+    private final UserRepository userRepository;
+    private final ObjectStorageService objectStorageService;
+
+    @Override
+    @JpaTransactional
+    public SellerBrandImageResponseDTO uploadBrandImage(UserPrincipal userPrincipal, MultipartFile imageFile) {
+        log.info("판매자 브랜드 이미지 업로드 요청 - provider: {}, providerId: {}, fileName: {}",
+                userPrincipal.provider(), userPrincipal.providerId(), imageFile.getOriginalFilename());
+
+        // 1. 이미지 파일 유효성 검증
+        validateImageFile(imageFile);
+
+        // 2. 사용자 조회
+        Users user = findUserByPrincipal(userPrincipal);
+
+        // 3. 판매자 정보 조회
+        Sellers seller = findSellerByUserId(user.getId());
+
+        // 4. 기존 이미지 삭제 (있는 경우)
+        deleteExistingImage(seller.getVendorProfileImage());
+
+        // 5. 새 이미지 업로드
+        String newImageUrl = uploadNewImage(imageFile, seller.getUserId());
+
+        // 6. 판매자 정보 업데이트
+        seller.updateVendorProfileImage(newImageUrl);
+        Sellers savedSeller = sellersRepository.save(seller);
+
+        log.info("판매자 브랜드 이미지 업로드 완료 - userId: {}, imageUrl: {}", user.getId(), newImageUrl);
+
+        return SellerBrandImageResponseDTO.from(savedSeller);
+    }
+
+    /**
+     * 이미지 파일 유효성 검증
+     */
+    private void validateImageFile(MultipartFile imageFile) {
+        // 파일 존재 여부 확인
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new IllegalArgumentException("이미지 파일이 비어있습니다.");
+        }
+
+        // 파일 크기 확인 (10MB 제한)
+        long maxFileSize = 10 * 1024 * 1024; // 10MB
+        if (imageFile.getSize() > maxFileSize) {
+            throw new IllegalArgumentException("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+
+        // Content-Type 확인
+        String contentType = imageFile.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다.");
+        }
+
+        // 지원하는 이미지 형식 확인
+        if (!contentType.equals("image/jpeg") &&
+                !contentType.equals("image/png") &&
+                !contentType.equals("image/jpg") &&
+                !contentType.equals("image/webp")) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다. (JPEG, PNG, JPG, WebP만 지원)");
+        }
+
+        log.debug("이미지 파일 유효성 검증 완료 - fileName: {}, size: {}, contentType: {}",
+                imageFile.getOriginalFilename(), imageFile.getSize(), contentType);
+    }
+
+    /**
+     * UserPrincipal로 Users 엔티티 조회
+     */
+    private Users findUserByPrincipal(UserPrincipal userPrincipal) {
+        return userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(),
+                userPrincipal.providerId()
+        ).orElseThrow(() -> new EntityNotFoundException(
+                String.format("사용자를 찾을 수 없습니다 - provider: %s, providerId: %s",
+                        userPrincipal.provider(), userPrincipal.providerId())));
+    }
+
+    /**
+     * 판매자 정보 조회
+     */
+    private Sellers findSellerByUserId(String userId) {
+        return sellersRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("판매자 정보를 찾을 수 없습니다 - userId: " + userId));
+    }
+
+    /**
+     * 기존 이미지 삭제
+     */
+    private void deleteExistingImage(String existingImageUrl) {
+        if (existingImageUrl == null || existingImageUrl.trim().isEmpty()) {
+            log.debug("삭제할 기존 이미지가 없습니다.");
+            return;
+        }
+
+        try {
+            // URL에서 S3 키 추출 (images/ 부분 제거)
+            String imageKey = extractImageKeyFromUrl(existingImageUrl);
+            if (imageKey != null) {
+                objectStorageService.deleteImage(imageKey);
+                log.info("기존 브랜드 이미지 삭제 완료 - imageKey: {}", imageKey);
+            }
+        } catch (Exception e) {
+            // 기존 이미지 삭제 실패는 로그만 남기고 계속 진행
+            log.warn("기존 브랜드 이미지 삭제 실패 (계속 진행) - imageUrl: {}, error: {}",
+                    existingImageUrl, e.getMessage());
+        }
+    }
+
+    /**
+     * URL에서 이미지 키 추출
+     * 예: https://cdn.example.com/images/brand_image_123.jpg -> brand_image_123.jpg
+     */
+    private String extractImageKeyFromUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            // URL에서 마지막 '/' 이후의 파일명 추출
+            int lastSlashIndex = imageUrl.lastIndexOf('/');
+            if (lastSlashIndex != -1 && lastSlashIndex < imageUrl.length() - 1) {
+                return imageUrl.substring(lastSlashIndex + 1);
+            }
+        } catch (Exception e) {
+            log.warn("이미지 키 추출 실패 - imageUrl: {}, error: {}", imageUrl, e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * 새 이미지 업로드
+     */
+    private String uploadNewImage(MultipartFile imageFile, String userId) {
+        try {
+            // 고유한 파일명 생성 (UUID + 원본 확장자)
+            String uniqueFileName = generateUniqueFileName(imageFile.getOriginalFilename(), userId);
+
+            // S3에 업로드
+            String imageUrl = objectStorageService.uploadImage(
+                    uniqueFileName,
+                    imageFile.getInputStream(),
+                    imageFile.getSize(),
+                    imageFile.getContentType()
+            );
+
+            log.debug("새 브랜드 이미지 업로드 완료 - fileName: {}, imageUrl: {}", uniqueFileName, imageUrl);
+            return imageUrl;
+
+        } catch (IOException e) {
+            log.error("이미지 업로드 중 I/O 오류 발생 - fileName: {}", imageFile.getOriginalFilename(), e);
+            throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);
+        } catch (Exception e) {
+            log.error("이미지 업로드 중 예상치 못한 오류 발생 - fileName: {}", imageFile.getOriginalFilename(), e);
+            throw new RuntimeException("이미지 업로드 실패", e);
+        }
+    }
+
+    /**
+     * 고유한 파일명 생성
+     * 형식: brand_{userId}_{UUID}.{확장자}
+     */
+    private String generateUniqueFileName(String originalFileName, String userId) {
+        String extension = getFileExtension(originalFileName);
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+
+        // userId의 처음 8자리만 사용 (너무 길어지는 것 방지)
+        String shortUserId = userId.length() > 8 ? userId.substring(0, 8) : userId;
+
+        return String.format("brand_%s_%s.%s", shortUserId, uuid, extension);
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String fileName) {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            return "jpg"; // 기본값
+        }
+
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex != -1 && lastDotIndex < fileName.length() - 1) {
+            return fileName.substring(lastDotIndex + 1).toLowerCase();
+        }
+
+        return "jpg"; // 기본값
+    }
+}

--- a/src/main/java/com/team5/catdogeats/users/service/impl/SellerInfoServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/users/service/impl/SellerInfoServiceImpl.java
@@ -130,9 +130,6 @@ public class SellerInfoServiceImpl implements SellerInfoService {
             seller.updateVendorName(request.vendorName());
         }
 
-        if (request.vendorProfileImage() != null && !request.vendorProfileImage().trim().isEmpty()) {
-            seller.updateVendorProfileImage(request.vendorProfileImage());
-        }
 
         if (request.businessNumber() != null && !request.businessNumber().trim().isEmpty()) {
             validateBusinessNumberDuplication(userId, request.businessNumber());
@@ -234,22 +231,6 @@ public class SellerInfoServiceImpl implements SellerInfoService {
                     throw new DataIntegrityViolationException("이미 사용 중인 상점명입니다: " + vendorName);
                 });
     }
-
-    /**
-     * 기존 판매자 정보 업데이트
-     */
-    private void updateSellerInfo(Sellers seller, SellerInfoRequestDTO request) {
-        seller.updateVendorName(request.vendorName());
-        seller.updateVendorProfileImage(request.vendorProfileImage());
-        seller.updateBusinessNumber(request.businessNumber());
-        seller.updateSettlementBank(request.settlementBank());
-        seller.updateSettlementAcc(request.settlementAcc());
-        seller.updateTags(request.tags());
-        seller.updateOperatingStartTime(request.operatingStartTime());
-        seller.updateOperatingEndTime(request.operatingEndTime());
-        seller.updateClosedDays(request.closedDays());
-    }
-
     /**
      * 새 판매자 정보 생성
      */
@@ -257,7 +238,6 @@ public class SellerInfoServiceImpl implements SellerInfoService {
         return Sellers.builder()
                 .user(user)
                 .vendorName(request.vendorName())
-                .vendorProfileImage(request.vendorProfileImage())
                 .businessNumber(request.businessNumber())
                 .settlementBank(request.settlementBank())
                 .settlementAccount(request.settlementAcc())

--- a/src/test/java/com/team5/catdogeats/storage/util/ImageValidationUtilTest.java
+++ b/src/test/java/com/team5/catdogeats/storage/util/ImageValidationUtilTest.java
@@ -1,0 +1,668 @@
+package com.team5.catdogeats.storage.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("ImageValidationUtil 테스트")
+class ImageValidationUtilTest {
+
+    private ImageValidationUtil imageValidationUtil;
+
+    @BeforeEach
+    void setUp() {
+        imageValidationUtil = new ImageValidationUtil();
+    }
+
+    @Nested
+    @DisplayName("통합 이미지 파일 검증 테스트")
+    class ValidateImageFileTest {
+
+        @Test
+        @DisplayName("성공: 유효한 JPEG 파일")
+        void validateImageFile_ValidJpegFile_Success() {
+            // given - JPEG magic number: FF D8 FF
+            byte[] jpegContent = createJpegContent();
+            MultipartFile jpegFile = new MockMultipartFile(
+                    "image", "test.jpg", "image/jpeg", jpegContent);
+
+            // when & then - 예외가 발생하지 않아야 함
+            assertThatCode(() -> imageValidationUtil.validateImageFile(jpegFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 유효한 PNG 파일")
+        void validateImageFile_ValidPngFile_Success() {
+            // given - PNG magic number: 89 50 4E 47
+            byte[] pngContent = createPngContent();
+            MultipartFile pngFile = new MockMultipartFile(
+                    "image", "test.png", "image/png", pngContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(pngFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 유효한 WebP 파일")
+        void validateImageFile_ValidWebPFile_Success() {
+            // given - WebP magic number: RIFF....WEBP
+            byte[] webpContent = createWebPContent();
+            MultipartFile webpFile = new MockMultipartFile(
+                    "image", "test.webp", "image/webp", webpContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(webpFile))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 속성 검증 테스트")
+    class BasicPropertiesValidationTest {
+
+        @Test
+        @DisplayName("실패: null 파일")
+        void validateImageFile_NullFile_ThrowsException() {
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일이 비어있습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 빈 파일")
+        void validateImageFile_EmptyFile_ThrowsException() {
+            // given
+            MultipartFile emptyFile = new MockMultipartFile(
+                    "image", "empty.jpg", "image/jpeg", new byte[0]);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(emptyFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일이 비어있습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 파일 크기 10MB 초과")
+        void validateImageFile_FileSizeExceeded_ThrowsException() {
+            // given - 11MB 파일
+            byte[] largeContent = new byte[11 * 1024 * 1024];
+            // JPEG 헤더 추가
+            largeContent[0] = (byte) 0xFF;
+            largeContent[1] = (byte) 0xD8;
+            largeContent[2] = (byte) 0xFF;
+
+            MultipartFile largeFile = new MockMultipartFile(
+                    "image", "large.jpg", "image/jpeg", largeContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(largeFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("성공: 정확히 10MB 파일")
+        void validateImageFile_ExactlyMaxSize_Success() {
+            // given - 정확히 10MB
+            byte[] maxSizeContent = new byte[10 * 1024 * 1024];
+            // JPEG 헤더 추가
+            maxSizeContent[0] = (byte) 0xFF;
+            maxSizeContent[1] = (byte) 0xD8;
+            maxSizeContent[2] = (byte) 0xFF;
+
+            MultipartFile maxSizeFile = new MockMultipartFile(
+                    "image", "max.jpg", "image/jpeg", maxSizeContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(maxSizeFile))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("MIME Type 검증 테스트")
+    class MimeTypeValidationTest {
+
+        @Test
+        @DisplayName("실패: Content-Type이 null")
+        void validateImageFile_NullContentType_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile fileWithNullContentType = new MockMultipartFile(
+                    "image", "test.jpg", null, jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fileWithNullContentType))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일의 Content-Type을 확인할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 지원하지 않는 MIME Type - image/gif")
+        void validateImageFile_UnsupportedMimeType_Gif_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile gifFile = new MockMultipartFile(
+                    "image", "test.gif", "image/gif", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(gifFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("허용되지 않은 MIME 타입입니다: image/gif");
+        }
+
+        @Test
+        @DisplayName("실패: 지원하지 않는 MIME Type - text/plain")
+        void validateImageFile_UnsupportedMimeType_Text_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile textFile = new MockMultipartFile(
+                    "image", "test.txt", "text/plain", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(textFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("허용되지 않은 MIME 타입입니다: text/plain");
+        }
+
+        @Test
+        @DisplayName("성공: 지원되는 모든 MIME Type")
+        void validateImageFile_SupportedMimeTypes_Success() {
+            // given
+            byte[] jpegContent = createJpegContent();
+
+            String[] supportedTypes = {"image/jpeg", "image/jpg", "image/png", "image/webp"};
+            String[] fileNames = {"test.jpeg", "test.jpg", "test.png", "test.webp"};
+
+            for (int i = 0; i < supportedTypes.length; i++) {
+                MultipartFile file = new MockMultipartFile(
+                        "image", fileNames[i], supportedTypes[i], jpegContent);
+
+                // when & then
+                assertThatCode(() -> imageValidationUtil.validateImageFile(file))
+                        .doesNotThrowAnyException();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("파일명 보안 검증 테스트")
+    class FileNameSecurityValidationTest {
+
+        @Test
+        @DisplayName("실패: 파일명이 null")
+        void validateImageFile_NullFileName_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile fileWithNullName = new MockMultipartFile(
+                    "image", null, "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fileWithNullName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일명이 비어있습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 파일명이 빈 문자열")
+        void validateImageFile_EmptyFileName_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile fileWithEmptyName = new MockMultipartFile(
+                    "image", "", "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fileWithEmptyName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일명이 비어있습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 파일명이 255자 초과")
+        void validateImageFile_FileNameTooLong_ThrowsException() {
+            // given
+            String longFileName = "a".repeat(256) + ".jpg";
+            byte[] jpegContent = createJpegContent();
+            MultipartFile fileWithLongName = new MockMultipartFile(
+                    "image", longFileName, "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fileWithLongName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일명이 너무 깁니다. (최대 255자)");
+        }
+
+        @Test
+        @DisplayName("성공: 파일명이 정확히 255자")
+        void validateImageFile_FileNameExactly255Chars_Success() {
+            // given - 정확히 255자 (확장자 포함)
+            String exactLengthFileName = "a".repeat(251) + ".jpg"; // 251 + 4 = 255
+            byte[] jpegContent = createJpegContent();
+            MultipartFile file = new MockMultipartFile(
+                    "image", exactLengthFileName, "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(file))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패: 경로 순회 공격 - ../ 포함")
+        void validateImageFile_PathTraversal_DotDotSlash_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile maliciousFile = new MockMultipartFile(
+                    "image", "../../../etc/passwd.jpg", "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일명에 상대경로가 포함될 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실파: 경로 순회 공격 - ..\\ 포함 (Windows)")
+        void validateImageFile_PathTraversal_DotDotBackslash_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile maliciousFile = new MockMultipartFile(
+                    "image", "..\\..\\system32\\test.jpg", "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일명에 상대경로가 포함될 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 실행 가능한 파일 확장자들")
+        void validateImageFile_ExecutableExtensions_ThrowsException() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            String[] dangerousExtensions = {
+                    "malicious.exe.jpg", "virus.bat.jpg", "script.js.jpg",
+                    "page.html.jpg", "code.php.jpg", "app.jsp.jpg"
+            };
+
+            for (String fileName : dangerousExtensions) {
+                MultipartFile maliciousFile = new MockMultipartFile(
+                        "image", fileName, "image/jpeg", jpegContent);
+
+                // when & then
+                assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("실행 가능한 파일 확장자는 업로드할 수 없습니다.");
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 안전한 파일명들")
+        void validateImageFile_SafeFileNames_Success() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            String[] safeFileNames = {
+                    "normal.jpg", "image_01.png", "photo-2024.webp",
+                    "IMG_001.JPEG", "screenshot.JPG", "profile.PNG"
+            };
+
+            for (String fileName : safeFileNames) {
+                MultipartFile safeFile = new MockMultipartFile(
+                        "image", fileName, "image/jpeg", jpegContent);
+
+                // when & then
+                assertThatCode(() -> imageValidationUtil.validateImageFile(safeFile))
+                        .doesNotThrowAnyException();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("스크립트 공격 방지 테스트")
+    class ScriptAttackPreventionTest {
+
+        @Test
+        @DisplayName("실패: <script> 태그 포함")
+        void validateImageFile_ContainsScriptTag_ThrowsException() {
+            // given - JPEG 헤더 + 스크립트 내용
+            String maliciousContent = createJpegHeaderString() + "<script>alert('XSS')</script>";
+            MultipartFile maliciousFile = new MockMultipartFile(
+                    "image", "malicious.jpg", "image/jpeg", maliciousContent.getBytes());
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("보안상 위험한 스크립트가 포함된 파일은 업로드할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: javascript: 스키마 포함")
+        void validateImageFile_ContainsJavaScriptSchema_ThrowsException() {
+            // given
+            String maliciousContent = createJpegHeaderString() + "javascript:alert('XSS')";
+            MultipartFile maliciousFile = new MockMultipartFile(
+                    "image", "malicious.jpg", "image/jpeg", maliciousContent.getBytes());
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("보안상 위험한 스크립트가 포함된 파일은 업로드할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("실패: 이벤트 핸들러들 포함")
+        void validateImageFile_ContainsEventHandlers_ThrowsException() {
+            // given
+            String[] eventHandlers = {"onload=", "onerror=", "onclick=", "eval(", "document.", "alert("};
+
+            for (String handler : eventHandlers) {
+                String maliciousContent = createJpegHeaderString() + handler + "malicious()";
+                MultipartFile maliciousFile = new MockMultipartFile(
+                        "image", "malicious.jpg", "image/jpeg", maliciousContent.getBytes());
+
+                // when & then
+                assertThatThrownBy(() -> imageValidationUtil.validateImageFile(maliciousFile))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("보안상 위험한 스크립트가 포함된 파일은 업로드할 수 없습니다.");
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 스크립트가 없는 정상 파일")
+        void validateImageFile_NoScript_Success() {
+            // given - 정상적인 JPEG 파일 (텍스트 없음)
+            byte[] cleanJpegContent = createJpegContent();
+            MultipartFile cleanFile = new MockMultipartFile(
+                    "image", "clean.jpg", "image/jpeg", cleanJpegContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(cleanFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 무해한 텍스트 포함")
+        void validateImageFile_HarmlessText_Success() {
+            // given - 올바른 JPEG 바이트 배열 + 무해한 텍스트
+            byte[] jpegHeader = createJpegContent(); // 올바른 JPEG magic number 바이트 배열
+            String harmlessText = "This is a normal image description";
+            byte[] harmlessTextBytes = harmlessText.getBytes();
+
+            // JPEG 헤더와 텍스트를 결합
+            byte[] combinedContent = new byte[jpegHeader.length + harmlessTextBytes.length];
+            System.arraycopy(jpegHeader, 0, combinedContent, 0, jpegHeader.length);
+            System.arraycopy(harmlessTextBytes, 0, combinedContent, jpegHeader.length, harmlessTextBytes.length);
+
+            MultipartFile harmlessFile = new MockMultipartFile(
+                    "image", "harmless.jpg", "image/jpeg", combinedContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(harmlessFile))
+                    .doesNotThrowAnyException();
+        }
+
+
+        @Test
+        @DisplayName("성공: 순수한 JPEG 파일")
+        void validateImageFile_PureJpegFile_Success() {
+            // given - createJpegContent()로 생성된 올바른 JPEG 바이트 배열
+            byte[] jpegContent = createJpegContent();
+            MultipartFile jpegFile = new MockMultipartFile(
+                    "image", "pure.jpg", "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(jpegFile))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("파일 시그니처 검증 테스트")
+    class FileSignatureValidationTest {
+
+        @Test
+        @DisplayName("실패: 잘못된 파일 시그니처 - PDF")
+        void validateImageFile_WrongSignature_PDF_ThrowsException() {
+            // given - PDF 시그니처 (25 50 44 46)
+            byte[] pdfContent = {0x25, 0x50, 0x44, 0x46}; // %PDF
+            MultipartFile fakeImageFile = new MockMultipartFile(
+                    "image", "fake.jpg", "image/jpeg", pdfContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fakeImageFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("지원하지 않는 이미지 형식입니다. (JPEG, PNG, WebP만 지원)");
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 파일 시그니처 - ZIP")
+        void validateImageFile_WrongSignature_ZIP_ThrowsException() {
+            // given - ZIP 시그니처 (50 4B 03 04)
+            byte[] zipContent = {0x50, 0x4B, 0x03, 0x04}; // PK..
+            MultipartFile fakeImageFile = new MockMultipartFile(
+                    "image", "fake.jpg", "image/jpeg", zipContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(fakeImageFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("지원하지 않는 이미지 형식입니다. (JPEG, PNG, WebP만 지원)");
+        }
+
+        @Test
+        @DisplayName("실패: 너무 짧은 파일 헤더")
+        void validateImageFile_TooShortHeader_ThrowsException() {
+            // given - 3바이트만 있는 파일
+            byte[] shortContent = {0x12, 0x34, 0x56};
+            MultipartFile shortFile = new MockMultipartFile(
+                    "image", "short.jpg", "image/jpeg", shortContent);
+
+            // when & then
+            assertThatThrownBy(() -> imageValidationUtil.validateImageFile(shortFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("파일 형식을 확인할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("성공: 올바른 JPEG 시그니처 (FF D8 FF)")
+        void validateImageFile_CorrectJpegSignature_Success() {
+            // given
+            byte[] jpegContent = createJpegContent();
+            MultipartFile jpegFile = new MockMultipartFile(
+                    "image", "valid.jpg", "image/jpeg", jpegContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(jpegFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 올바른 PNG 시그니처 (89 50 4E 47)")
+        void validateImageFile_CorrectPngSignature_Success() {
+            // given
+            byte[] pngContent = createPngContent();
+            MultipartFile pngFile = new MockMultipartFile(
+                    "image", "valid.png", "image/png", pngContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(pngFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 올바른 WebP 시그니처 (RIFF....WEBP)")
+        void validateImageFile_CorrectWebPSignature_Success() {
+            // given
+            byte[] webpContent = createWebPContent();
+            MultipartFile webpFile = new MockMultipartFile(
+                    "image", "valid.webp", "image/webp", webpContent);
+
+            // when & then
+            assertThatCode(() -> imageValidationUtil.validateImageFile(webpFile))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패: MIME Type과 시그니처 불일치")
+        void validateImageFile_MimeTypeSignatureMismatch_ThrowsException() {
+            // given - PNG 시그니처지만 JPEG MIME Type
+            byte[] pngContent = createPngContent();
+            MultipartFile mismatchFile = new MockMultipartFile(
+                    "image", "mismatch.jpg", "image/jpeg", pngContent);
+
+            // when & then - PNG 시그니처이므로 통과해야 함 (시그니처가 우선)
+            assertThatCode(() -> imageValidationUtil.validateImageFile(mismatchFile))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("파일 확장자 추출 테스트")
+    class GetFileExtensionTest {
+
+        @Test
+        @DisplayName("성공: 일반적인 파일 확장자들")
+        void getFileExtension_CommonExtensions_ReturnsCorrectExtension() {
+            // given & when & then
+            assertThat(imageValidationUtil.getFileExtension("image.jpg")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("photo.jpeg")).isEqualTo("jpeg");
+            assertThat(imageValidationUtil.getFileExtension("picture.png")).isEqualTo("png");
+            assertThat(imageValidationUtil.getFileExtension("graphic.webp")).isEqualTo("webp");
+        }
+
+        @Test
+        @DisplayName("성공: 대문자 확장자")
+        void getFileExtension_UpperCaseExtensions_ReturnsLowerCase() {
+            // given & when & then
+            assertThat(imageValidationUtil.getFileExtension("IMAGE.JPG")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("PHOTO.PNG")).isEqualTo("png");
+            assertThat(imageValidationUtil.getFileExtension("PICTURE.WEBP")).isEqualTo("webp");
+        }
+
+        @Test
+        @DisplayName("기본값 반환: null 파일명")
+        void getFileExtension_NullFileName_ReturnsDefault() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension(null)).isEqualTo("jpg");
+        }
+
+        @Test
+        @DisplayName("기본값 반환: 빈 파일명")
+        void getFileExtension_EmptyFileName_ReturnsDefault() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("   ")).isEqualTo("jpg");
+        }
+
+        @Test
+        @DisplayName("기본값 반환: 확장자 없는 파일명")
+        void getFileExtension_NoExtension_ReturnsDefault() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("filename")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("image_without_extension")).isEqualTo("jpg");
+        }
+
+        @Test
+        @DisplayName("기본값 반환: 지원하지 않는 확장자")
+        void getFileExtension_UnsupportedExtension_ReturnsDefault() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("file.gif")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("document.pdf")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("archive.zip")).isEqualTo("jpg");
+        }
+
+        @Test
+        @DisplayName("성공: 특수 문자가 포함된 파일명")
+        void getFileExtension_SpecialCharacters_ExtractsCorrectly() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("image@#$%.jpg")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("파일명.png")).isEqualTo("png");
+            assertThat(imageValidationUtil.getFileExtension("image with spaces.webp")).isEqualTo("webp");
+        }
+
+        @Test
+        @DisplayName("성공: 여러 점이 있는 파일명")
+        void getFileExtension_MultipleDots_ReturnsLastExtension() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("my.image.file.jpg")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("version.1.0.png")).isEqualTo("png");
+        }
+
+        @Test
+        @DisplayName("성공: 경로가 포함된 파일명")
+        void getFileExtension_WithPath_ExtractsCorrectly() {
+            // when & then
+            assertThat(imageValidationUtil.getFileExtension("/path/to/image.jpg")).isEqualTo("jpg");
+            assertThat(imageValidationUtil.getFileExtension("C:\\Users\\Documents\\photo.png")).isEqualTo("png");
+        }
+    }
+
+    // === Helper Methods ===
+
+    /**
+     * 유효한 JPEG 파일 내용 생성
+     * Magic Number: FF D8 FF + 더미 데이터
+     */
+    private byte[] createJpegContent() {
+        byte[] content = new byte[100];
+        content[0] = (byte) 0xFF; // JPEG magic number
+        content[1] = (byte) 0xD8;
+        content[2] = (byte) 0xFF;
+        content[3] = (byte) 0xE0; // JFIF marker
+        return content;
+    }
+
+    /**
+     * 유효한 PNG 파일 내용 생성
+     * Magic Number: 89 50 4E 47
+     */
+    private byte[] createPngContent() {
+        byte[] content = new byte[100];
+        content[0] = (byte) 0x89; // PNG magic number
+        content[1] = 0x50;        // P
+        content[2] = 0x4E;        // N
+        content[3] = 0x47;        // G
+        content[4] = 0x0D;
+        content[5] = 0x0A;
+        content[6] = 0x1A;
+        content[7] = 0x0A;
+        return content;
+    }
+
+    /**
+     * 유효한 WebP 파일 내용 생성
+     * Magic Number: RIFF....WEBP
+     */
+    private byte[] createWebPContent() {
+        byte[] content = new byte[100];
+        // RIFF header
+        content[0] = 0x52; // R
+        content[1] = 0x49; // I
+        content[2] = 0x46; // F
+        content[3] = 0x46; // F
+        // 파일 크기 (little endian) - 4바이트
+        content[4] = 0x00;
+        content[5] = 0x00;
+        content[6] = 0x00;
+        content[7] = 0x00;
+        // WEBP header
+        content[8] = 0x57;  // W
+        content[9] = 0x45;  // E
+        content[10] = 0x42; // B
+        content[11] = 0x50; // P
+        return content;
+    }
+
+    /**
+     * 스크립트 테스트용 JPEG 헤더 문자열 생성
+     */
+    private String createJpegHeaderString() {
+        return "\u00FF\u00D8\u00FF\u00E0"; // JPEG magic number를 문자열로
+    }
+}

--- a/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
+++ b/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
@@ -4,12 +4,14 @@ import com.team5.catdogeats.auth.dto.UserPrincipal;
 import com.team5.catdogeats.storage.service.ObjectStorageService;
 import com.team5.catdogeats.users.domain.Users;
 import com.team5.catdogeats.users.domain.dto.SellerBrandImageResponseDTO;
+import com.team5.catdogeats.users.domain.enums.Role;
 import com.team5.catdogeats.users.domain.mapping.Sellers;
 import com.team5.catdogeats.users.repository.SellersRepository;
 import com.team5.catdogeats.users.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -18,16 +20,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
+import java.io.InputStream;
+
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("SellerBrandImageServiceImpl 테스트")
 class SellerBrandImageServiceImplTest {
 
     @Mock
@@ -49,388 +53,474 @@ class SellerBrandImageServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        // UserPrincipal 생성
         userPrincipal = new UserPrincipal("google", "12345");
 
-        // Users 엔티티 생성
         user = Users.builder()
                 .id("user-uuid-123")
                 .provider("google")
                 .providerId("12345")
-                .name("테스트 사용자")
+                .name("Test User")
+                .role(Role.ROLE_SELLER)
+                .userNameAttribute("sub")
                 .build();
 
-        // Sellers 엔티티 생성
         seller = Sellers.builder()
                 .userId("user-uuid-123")
                 .user(user)
-                .vendorName("멍멍이네 수제간식")
-                .vendorProfileImage("https://cdn.example.com/images/old_brand_image.jpg")
+                .vendorName("테스트 상점")
+                .vendorProfileImage("https://cdn.example.com/images/old_image.jpg")
                 .businessNumber("123-45-67890")
                 .build();
 
-        // 유효한 이미지 파일 생성
+        // Valid JPEG file mock (JPEG magic number: FF D8 FF)
+        byte[] jpegHeader = new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
         validImageFile = new MockMultipartFile(
                 "image",
-                "brand_image.jpg",
+                "test.jpg",
                 "image/jpeg",
-                "test image content".getBytes()
+                jpegHeader
         );
     }
 
+    @Nested
+    @DisplayName("브랜드 이미지 업로드 테스트")
+    class UploadBrandImageTest {
 
-
-    @Test
-    @DisplayName("브랜드 이미지 업로드 성공")
-    void uploadBrandImage_Success() throws IOException {
-        // given
-        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
-
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenReturn(newImageUrl);
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // when
-        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.userId()).isEqualTo("user-uuid-123");
-        assertThat(result.vendorName()).isEqualTo("멍멍이네 수제간식");
-
-        // 기존 이미지 삭제 호출 확인
-        verify(objectStorageService).deleteImage("old_brand_image.jpg");
-
-        // 새 이미지 업로드 호출 확인
-        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
-        verify(objectStorageService).uploadImage(
-                fileNameCaptor.capture(),
-                any(),
-                eq(validImageFile.getSize()),
-                eq("image/jpeg")
-        );
-
-        // 생성된 파일명이 올바른 형식인지 확인
-        String capturedFileName = fileNameCaptor.getValue();
-        assertThat(capturedFileName).startsWith("brand_123_");
-        assertThat(capturedFileName).endsWith(".jpg");
-
-        // 더 구체적인 형식 검증: brand_123_{32자리UUID}.jpg
-        assertThat(capturedFileName).matches("brand_123_[a-f0-9]{32}\\.jpg");
-
-        assertThat(capturedFileName.length()).isBetween(45, 50); // 범위로 검증
-
-        // 판매자 정보 저장 호출 확인
-        verify(sellersRepository).save(seller);
-    }
-
-    @Test
-    @DisplayName("브랜드 이미지 업로드 성공 - 기존 이미지가 없는 경우")
-    void uploadBrandImage_Success_NoExistingImage() throws IOException {
-        // given
-        seller = Sellers.builder()
-                .userId("user-uuid-123")
-                .user(user)
-                .vendorName("멍멍이네 수제간식")
-                .vendorProfileImage(null) // 기존 이미지 없음
-                .businessNumber("123-45-67890")
-                .build();
-
-        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
-
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenReturn(newImageUrl);
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // when
-        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
-
-        // then
-        assertThat(result).isNotNull();
-
-        // 기존 이미지 삭제는 호출되지 않아야 함
-        verify(objectStorageService, never()).deleteImage(anyString());
-
-        // 새 이미지 업로드는 호출되어야 함
-        verify(objectStorageService).uploadImage(anyString(), any(), anyLong(), anyString());
-    }
-
-    @Test
-    @DisplayName("브랜드 이미지 삭제 성공")
-    void deleteBrandImage_Success() {
-        // given
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // when
-        SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.userId()).isEqualTo("user-uuid-123");
-
-        // S3에서 이미지 삭제 호출 확인
-        verify(objectStorageService).deleteImage("old_brand_image.jpg");
-
-        // 판매자 정보 저장 호출 확인 (이미지 URL이 null로 설정됨)
-        ArgumentCaptor<Sellers> sellerCaptor = ArgumentCaptor.forClass(Sellers.class);
-        verify(sellersRepository).save(sellerCaptor.capture());
-    }
-
-    @Test
-    @DisplayName("브랜드 이미지 삭제 성공 - 기존 이미지가 없는 경우")
-    void deleteBrandImage_Success_NoExistingImage() {
-        // given
-        seller = Sellers.builder()
-                .userId("user-uuid-123")
-                .user(user)
-                .vendorName("멍멍이네 수제간식")
-                .vendorProfileImage(null) // 기존 이미지 없음
-                .businessNumber("123-45-67890")
-                .build();
-
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // when
-        SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
-
-        // then
-        assertThat(result).isNotNull();
-
-        // S3 삭제는 호출되지 않아야 함
-        verify(objectStorageService, never()).deleteImage(anyString());
-
-        // 판매자 정보 저장은 호출되어야 함
-        verify(sellersRepository).save(seller);
-    }
-
-    @Test
-    @DisplayName("이미지 파일 유효성 검증 실패 - null 파일")
-    void uploadBrandImage_Fail_NullFile() {
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미지 파일이 비어있습니다.");
-    }
-
-    @Test
-    @DisplayName("이미지 파일 유효성 검증 실패 - 빈 파일")
-    void uploadBrandImage_Fail_EmptyFile() {
-        // given
-        MultipartFile emptyFile = new MockMultipartFile(
-                "image", "empty.jpg", "image/jpeg", new byte[0]
-        );
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, emptyFile))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미지 파일이 비어있습니다.");
-    }
-
-    @Test
-    @DisplayName("이미지 파일 유효성 검증 실패 - 파일 크기 초과")
-    void uploadBrandImage_Fail_FileSizeExceeded() {
-        // given - 11MB 파일 생성
-        byte[] largeContent = new byte[11 * 1024 * 1024];
-        MultipartFile largeFile = new MockMultipartFile(
-                "image", "large.jpg", "image/jpeg", largeContent
-        );
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, largeFile))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("이미지 파일 유효성 검증 실패 - 지원하지 않는 파일 형식")
-    void uploadBrandImage_Fail_UnsupportedFileType() {
-        // given
-        MultipartFile textFile = new MockMultipartFile(
-                "file", "document.txt", "text/plain", "text content".getBytes()
-        );
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, textFile))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미지 파일만 업로드 가능합니다.");
-    }
-
-    @Test
-    @DisplayName("이미지 파일 유효성 검증 실패 - 지원하지 않는 이미지 형식")
-    void uploadBrandImage_Fail_UnsupportedImageFormat() {
-        // given
-        MultipartFile gifFile = new MockMultipartFile(
-                "image", "animated.gif", "image/gif", "gif content".getBytes()
-        );
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, gifFile))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("지원하지 않는 이미지 형식입니다. (JPEG, PNG, JPG, WebP만 지원)");
-    }
-
-    @Test
-    @DisplayName("사용자 조회 실패")
-    void uploadBrandImage_Fail_UserNotFound() {
-        // given
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("사용자를 찾을 수 없습니다");
-    }
-
-    @Test
-    @DisplayName("판매자 조회 실패")
-    void uploadBrandImage_Fail_SellerNotFound() {
-        // given
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("판매자 정보를 찾을 수 없습니다");
-    }
-
-    @Test
-    @DisplayName("S3 업로드 실패로 인한 예외")
-    void uploadBrandImage_Fail_S3UploadError() throws IOException {
-        // given
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenThrow(new RuntimeException("S3 업로드 실패"));
-
-        // when & then
-        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("이미지 업로드 실패");
-    }
-
-    @Test
-    @DisplayName("기존 이미지 삭제 실패해도 업로드는 계속 진행")
-    void uploadBrandImage_Success_IgnoreDeleteError() throws IOException {
-        // given
-        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
-
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        doThrow(new RuntimeException("S3 삭제 실패"))
-                .when(objectStorageService).deleteImage("old_brand_image.jpg");
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenReturn(newImageUrl);
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // when
-        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
-
-        // then
-        assertThat(result).isNotNull();
-
-        // 기존 이미지 삭제 시도는 했지만 실패
-        verify(objectStorageService).deleteImage("old_brand_image.jpg");
-
-        // 새 이미지 업로드는 성공
-        verify(objectStorageService).uploadImage(anyString(), any(), anyLong(), anyString());
-
-        // 최종 저장도 성공
-        verify(sellersRepository).save(seller);
-    }
-
-    @Test
-    @DisplayName("지원하는 모든 이미지 형식 테스트")
-    void uploadBrandImage_Success_AllSupportedFormats() throws IOException {
-        // given
-        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
-
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenReturn(newImageUrl);
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
-
-        // 지원하는 모든 형식 테스트
-        String[] supportedTypes = {"image/jpeg", "image/png", "image/jpg", "image/webp"};
-        String[] extensions = {"jpeg", "png", "jpg", "webp"};
-
-        for (int i = 0; i < supportedTypes.length; i++) {
+        @Test
+        @DisplayName("성공: 새 브랜드 이미지 업로드")
+        void uploadBrandImage_Success() throws IOException {
             // given
-            MultipartFile imageFile = new MockMultipartFile(
-                    "image",
-                    "test." + extensions[i],
-                    supportedTypes[i],
-                    "test content".getBytes()
-            );
+            String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_new123.jpg";
 
-            // when & then (예외가 발생하지 않아야 함)
-            SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, imageFile);
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(objectStorageService.uploadImage(anyString(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn(newImageUrl);
+
+            Sellers updatedSeller = Sellers.builder()
+                    .userId("user-uuid-123")
+                    .user(user)
+                    .vendorName("테스트 상점")
+                    .vendorProfileImage(newImageUrl)
+                    .businessNumber("123-45-67890")
+                    .build();
+
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(updatedSeller);
+
+            // when
+            SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+            // then
             assertThat(result).isNotNull();
+            assertThat(result.userId()).isEqualTo("user-uuid-123");
+            assertThat(result.vendorName()).isEqualTo("테스트 상점");
+            assertThat(result.vendorProfileImage()).isEqualTo(newImageUrl);
+
+            // verify interactions
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository).findByUserId("user-uuid-123");
+            verify(objectStorageService).deleteImage("old_image.jpg"); // 기존 이미지 삭제
+            verify(objectStorageService).uploadImage(anyString(), any(InputStream.class), anyLong(), eq("image/jpeg"));
+            verify(sellersRepository).save(any(Sellers.class));
         }
 
-        // 모든 형식에 대해 업로드가 호출되었는지 확인
-        verify(objectStorageService, times(4)).uploadImage(anyString(), any(), anyLong(), anyString());
+        @Test
+        @DisplayName("실패: 사용자를 찾을 수 없음")
+        void uploadBrandImage_UserNotFound() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("사용자를 찾을 수 없습니다");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verifyNoInteractions(sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 판매자 정보를 찾을 수 없음")
+        void uploadBrandImage_SellerNotFound() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("판매자 정보를 찾을 수 없습니다");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository).findByUserId("user-uuid-123");
+            verifyNoInteractions(objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 이미지 파일이 null")
+        void uploadBrandImage_NullFile() {
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일이 비어있습니다.");
+
+            verifyNoInteractions(userRepository, sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 이미지 파일이 비어있음")
+        void uploadBrandImage_EmptyFile() {
+            // given
+            MultipartFile emptyFile = new MockMultipartFile("image", "empty.jpg", "image/jpeg", new byte[0]);
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, emptyFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일이 비어있습니다.");
+
+            verifyNoInteractions(userRepository, sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 파일 크기가 10MB 초과")
+        void uploadBrandImage_FileSizeExceeded() {
+            // given
+            byte[] largeFile = new byte[11 * 1024 * 1024]; // 11MB
+            largeFile[0] = (byte) 0xFF; largeFile[1] = (byte) 0xD8; largeFile[2] = (byte) 0xFF; // JPEG header
+
+            MultipartFile largeSizeFile = new MockMultipartFile("image", "large.jpg", "image/jpeg", largeFile);
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, largeSizeFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
+
+            verifyNoInteractions(userRepository, sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 지원하지 않는 파일 형식")
+        void uploadBrandImage_UnsupportedFileType() {
+            // given - PDF 파일 헤더 (25 50 44 46)
+            byte[] pdfHeader = new byte[]{0x25, 0x50, 0x44, 0x46};
+            MultipartFile unsupportedFile = new MockMultipartFile("image", "test.pdf", "application/pdf", pdfHeader);
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, unsupportedFile))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("지원하지 않는 이미지 형식입니다. (JPEG, PNG, WebP만 지원)");
+
+            verifyNoInteractions(userRepository, sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: S3 업로드 중 IOException 발생")
+        void uploadBrandImage_S3UploadFailed() throws IOException {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(objectStorageService.uploadImage(anyString(), any(InputStream.class), anyLong(), anyString()))
+                    .thenThrow(new RuntimeException("S3 업로드 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("이미지 업로드 실패");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository).findByUserId("user-uuid-123");
+            verify(objectStorageService).deleteImage("old_image.jpg");
+            verify(objectStorageService).uploadImage(anyString(), any(InputStream.class), anyLong(), anyString());
+            verify(sellersRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("성공: PNG 파일 업로드")
+        void uploadBrandImage_PngFile() throws IOException {
+            // given - PNG magic number: 89 50 4E 47
+            byte[] pngHeader = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+            MultipartFile pngFile = new MockMultipartFile("image", "test.png", "image/png", pngHeader);
+            String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_new123.png";
+
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(objectStorageService.uploadImage(anyString(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn(newImageUrl);
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(seller);
+
+            // when
+            SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, pngFile);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(objectStorageService).uploadImage(anyString(), any(InputStream.class), anyLong(), eq("image/png"));
+        }
+
+        @Test
+        @DisplayName("성공: WebP 파일 업로드")
+        void uploadBrandImage_WebPFile() throws IOException {
+            // given - WebP magic number: RIFF....WEBP
+            byte[] webpHeader = new byte[]{0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50};
+            MultipartFile webpFile = new MockMultipartFile("image", "test.webp", "image/webp", webpHeader);
+            String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_new123.webp";
+
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(objectStorageService.uploadImage(anyString(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn(newImageUrl);
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(seller);
+
+            // when
+            SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, webpFile);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(objectStorageService).uploadImage(anyString(), any(InputStream.class), anyLong(), eq("image/webp"));
+        }
     }
 
-    @Test
-    @DisplayName("파일명에서 확장자 추출 테스트")
-    void extractFileExtension_Test() {
-        // private 메서드이므로 실제로는 업로드를 통해 간접적으로 테스트
-        // given
-        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
-                .thenReturn(Optional.of(user));
-        when(sellersRepository.findByUserId(anyString()))
-                .thenReturn(Optional.of(seller));
-        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
-                .thenReturn("test-url");
-        when(sellersRepository.save(any(Sellers.class)))
-                .thenReturn(seller);
+    @Nested
+    @DisplayName("브랜드 이미지 삭제 테스트")
+    class DeleteBrandImageTest {
 
-        MultipartFile pngFile = new MockMultipartFile(
-                "image", "test.PNG", "image/png", "content".getBytes()
-        );
+        @Test
+        @DisplayName("성공: 브랜드 이미지 삭제")
+        void deleteBrandImage_Success() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(sellersRepository.deleteVendorProfileImage("user-uuid-123"))
+                    .thenReturn(1);
 
-        // when
-        sellerBrandImageService.uploadBrandImage(userPrincipal, pngFile);
+            Sellers updatedSeller = Sellers.builder()
+                    .userId("user-uuid-123")
+                    .user(user)
+                    .vendorName("테스트 상점")
+                    .vendorProfileImage(null) // 이미지 삭제됨
+                    .businessNumber("123-45-67890")
+                    .build();
 
-        // then
-        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
-        verify(objectStorageService).uploadImage(fileNameCaptor.capture(), any(), anyLong(), anyString());
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller))
+                    .thenReturn(Optional.of(updatedSeller));
 
-        String capturedFileName = fileNameCaptor.getValue();
-        assertThat(capturedFileName).endsWith(".png"); // 소문자로 변환되어야 함
-        assertThat(capturedFileName).matches("brand_123_[a-f0-9]{32}\\.png"); // PNG 확장자 확인
+            // when
+            SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.userId()).isEqualTo("user-uuid-123");
+            assertThat(result.vendorProfileImage()).isNull();
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository, times(2)).findByUserId("user-uuid-123");
+            verify(objectStorageService).deleteImage("old_image.jpg");
+            verify(sellersRepository).deleteVendorProfileImage("user-uuid-123");
+        }
+
+        @Test
+        @DisplayName("성공: 삭제할 이미지가 없는 경우")
+        void deleteBrandImage_NoExistingImage() {
+            // given
+            Sellers sellerWithoutImage = Sellers.builder()
+                    .userId("user-uuid-123")
+                    .user(user)
+                    .vendorName("테스트 상점")
+                    .vendorProfileImage(null)
+                    .businessNumber("123-45-67890")
+                    .build();
+
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(sellerWithoutImage));
+            when(sellersRepository.deleteVendorProfileImage("user-uuid-123"))
+                    .thenReturn(1);
+
+            // when
+            SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.vendorProfileImage()).isNull();
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository, times(2)).findByUserId("user-uuid-123");
+            verify(objectStorageService, never()).deleteImage(anyString());
+            verify(sellersRepository).deleteVendorProfileImage("user-uuid-123");
+        }
+
+        @Test
+        @DisplayName("실패: 사용자를 찾을 수 없음")
+        void deleteBrandImage_UserNotFound() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.deleteBrandImage(userPrincipal))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("사용자를 찾을 수 없습니다");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verifyNoInteractions(sellersRepository, objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: 판매자 정보를 찾을 수 없음")
+        void deleteBrandImage_SellerNotFound() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.deleteBrandImage(userPrincipal))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("판매자 정보를 찾을 수 없습니다");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository).findByUserId("user-uuid-123");
+            verifyNoInteractions(objectStorageService);
+        }
+
+        @Test
+        @DisplayName("실패: DB 업데이트 실패")
+        void deleteBrandImage_DatabaseUpdateFailed() {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(sellersRepository.deleteVendorProfileImage("user-uuid-123"))
+                    .thenReturn(0); // 업데이트된 행이 없음
+
+            // when & then
+            assertThatThrownBy(() -> sellerBrandImageService.deleteBrandImage(userPrincipal))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("브랜드 이미지 삭제에 실패했습니다.");
+
+            verify(userRepository).findByProviderAndProviderId("google", "12345");
+            verify(sellersRepository).findByUserId("user-uuid-123");
+            verify(objectStorageService).deleteImage("old_image.jpg");
+            verify(sellersRepository).deleteVendorProfileImage("user-uuid-123");
+        }
+    }
+
+    @Nested
+    @DisplayName("Private 메서드 간접 테스트")
+    class PrivateMethodIndirectTest {
+
+        @Test
+        @DisplayName("파일명 생성 검증 - UUID 형식")
+        void generateUniqueFileName_Verification() throws IOException {
+            // given
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(seller));
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(seller);
+
+            ArgumentCaptor<String> filenameCaptor = ArgumentCaptor.forClass(String.class);
+            when(objectStorageService.uploadImage(filenameCaptor.capture(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn("https://cdn.example.com/images/generated_filename.jpg");
+
+            // when
+            sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+            // then
+            String generatedFilename = filenameCaptor.getValue();
+            // user-uuid-123에서 8자리 잘림: user-uui
+            assertThat(generatedFilename).matches("brand_user-uui_[a-f0-9]{32}\\.jpg");
+            assertThat(generatedFilename).startsWith("brand_user-uui");
+            assertThat(generatedFilename).endsWith(".jpg");
+        }
+
+        @Test
+        @DisplayName("이미지 키 추출 검증")
+        void extractImageKeyFromUrl_Verification() throws IOException {
+            // given - 여러 다른 URL 형식으로 seller 설정
+            Sellers sellerWithDifferentUrl = Sellers.builder()
+                    .userId("user-uuid-123")
+                    .user(user)
+                    .vendorName("테스트 상점")
+                    .vendorProfileImage("https://cdn.example.com/images/some_image_key.jpg")
+                    .businessNumber("123-45-67890")
+                    .build();
+
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(user));
+            when(sellersRepository.findByUserId("user-uuid-123"))
+                    .thenReturn(Optional.of(sellerWithDifferentUrl));
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(sellerWithDifferentUrl);
+            when(objectStorageService.uploadImage(anyString(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn("https://cdn.example.com/images/new_image.jpg");
+
+            ArgumentCaptor<String> imageKeyCaptor = ArgumentCaptor.forClass(String.class);
+
+            // when
+            sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+            // then
+            verify(objectStorageService).deleteImage(imageKeyCaptor.capture());
+            String extractedKey = imageKeyCaptor.getValue();
+            assertThat(extractedKey).isEqualTo("some_image_key.jpg");
+        }
+
+        @Test
+        @DisplayName("8자리 이하 userId 파일명 생성 검증")
+        void generateUniqueFileName_ShortUserId() throws IOException {
+            // given - 짧은 userId로 새로운 user 생성
+            Users shortUser = Users.builder()
+                    .id("short123")  // 8자리 이하
+                    .provider("google")
+                    .providerId("12345")
+                    .name("Test User")
+                    .role(Role.ROLE_SELLER)
+                    .userNameAttribute("sub")
+                    .build();
+
+            Sellers shortSeller = Sellers.builder()
+                    .userId("short123")
+                    .user(shortUser)
+                    .vendorName("테스트 상점")
+                    .vendorProfileImage("https://cdn.example.com/images/old_image.jpg")
+                    .businessNumber("123-45-67890")
+                    .build();
+
+            when(userRepository.findByProviderAndProviderId("google", "12345"))
+                    .thenReturn(Optional.of(shortUser));
+            when(sellersRepository.findByUserId("short123"))
+                    .thenReturn(Optional.of(shortSeller));
+            when(sellersRepository.save(any(Sellers.class))).thenReturn(shortSeller);
+
+            ArgumentCaptor<String> filenameCaptor = ArgumentCaptor.forClass(String.class);
+            when(objectStorageService.uploadImage(filenameCaptor.capture(), any(InputStream.class), anyLong(), anyString()))
+                    .thenReturn("https://cdn.example.com/images/generated_filename.jpg");
+
+            // when
+            sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+            // then
+            String generatedFilename = filenameCaptor.getValue();
+            // 짧은 userId는 그대로 사용됨
+            assertThat(generatedFilename).matches("brand_short123_[a-f0-9]{32}\\.jpg");
+            assertThat(generatedFilename).startsWith("brand_short123");
+            assertThat(generatedFilename).endsWith(".jpg");
+        }
     }
 }

--- a/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
+++ b/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
@@ -1,0 +1,436 @@
+package com.team5.catdogeats.users.service.impl;
+
+import com.team5.catdogeats.auth.dto.UserPrincipal;
+import com.team5.catdogeats.storage.service.ObjectStorageService;
+import com.team5.catdogeats.users.domain.Users;
+import com.team5.catdogeats.users.domain.dto.SellerBrandImageResponseDTO;
+import com.team5.catdogeats.users.domain.mapping.Sellers;
+import com.team5.catdogeats.users.repository.SellersRepository;
+import com.team5.catdogeats.users.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SellerBrandImageServiceImplTest {
+
+    @Mock
+    private SellersRepository sellersRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ObjectStorageService objectStorageService;
+
+    @InjectMocks
+    private SellerBrandImageServiceImpl sellerBrandImageService;
+
+    private UserPrincipal userPrincipal;
+    private Users user;
+    private Sellers seller;
+    private MultipartFile validImageFile;
+
+    @BeforeEach
+    void setUp() {
+        // UserPrincipal 생성
+        userPrincipal = new UserPrincipal("google", "12345");
+
+        // Users 엔티티 생성
+        user = Users.builder()
+                .id("user-uuid-123")
+                .provider("google")
+                .providerId("12345")
+                .name("테스트 사용자")
+                .build();
+
+        // Sellers 엔티티 생성
+        seller = Sellers.builder()
+                .userId("user-uuid-123")
+                .user(user)
+                .vendorName("멍멍이네 수제간식")
+                .vendorProfileImage("https://cdn.example.com/images/old_brand_image.jpg")
+                .businessNumber("123-45-67890")
+                .build();
+
+        // 유효한 이미지 파일 생성
+        validImageFile = new MockMultipartFile(
+                "image",
+                "brand_image.jpg",
+                "image/jpeg",
+                "test image content".getBytes()
+        );
+    }
+
+
+
+    @Test
+    @DisplayName("브랜드 이미지 업로드 성공")
+    void uploadBrandImage_Success() throws IOException {
+        // given
+        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
+
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenReturn(newImageUrl);
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // when
+        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.userId()).isEqualTo("user-uuid-123");
+        assertThat(result.vendorName()).isEqualTo("멍멍이네 수제간식");
+
+        // 기존 이미지 삭제 호출 확인
+        verify(objectStorageService).deleteImage("old_brand_image.jpg");
+
+        // 새 이미지 업로드 호출 확인
+        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(objectStorageService).uploadImage(
+                fileNameCaptor.capture(),
+                any(),
+                eq(validImageFile.getSize()),
+                eq("image/jpeg")
+        );
+
+        // 생성된 파일명이 올바른 형식인지 확인
+        String capturedFileName = fileNameCaptor.getValue();
+        assertThat(capturedFileName).startsWith("brand_123_");
+        assertThat(capturedFileName).endsWith(".jpg");
+
+        // 더 구체적인 형식 검증: brand_123_{32자리UUID}.jpg
+        assertThat(capturedFileName).matches("brand_123_[a-f0-9]{32}\\.jpg");
+
+        assertThat(capturedFileName.length()).isBetween(45, 50); // 범위로 검증
+
+        // 판매자 정보 저장 호출 확인
+        verify(sellersRepository).save(seller);
+    }
+
+    @Test
+    @DisplayName("브랜드 이미지 업로드 성공 - 기존 이미지가 없는 경우")
+    void uploadBrandImage_Success_NoExistingImage() throws IOException {
+        // given
+        seller = Sellers.builder()
+                .userId("user-uuid-123")
+                .user(user)
+                .vendorName("멍멍이네 수제간식")
+                .vendorProfileImage(null) // 기존 이미지 없음
+                .businessNumber("123-45-67890")
+                .build();
+
+        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
+
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenReturn(newImageUrl);
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // when
+        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // 기존 이미지 삭제는 호출되지 않아야 함
+        verify(objectStorageService, never()).deleteImage(anyString());
+
+        // 새 이미지 업로드는 호출되어야 함
+        verify(objectStorageService).uploadImage(anyString(), any(), anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("브랜드 이미지 삭제 성공")
+    void deleteBrandImage_Success() {
+        // given
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // when
+        SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.userId()).isEqualTo("user-uuid-123");
+
+        // S3에서 이미지 삭제 호출 확인
+        verify(objectStorageService).deleteImage("old_brand_image.jpg");
+
+        // 판매자 정보 저장 호출 확인 (이미지 URL이 null로 설정됨)
+        ArgumentCaptor<Sellers> sellerCaptor = ArgumentCaptor.forClass(Sellers.class);
+        verify(sellersRepository).save(sellerCaptor.capture());
+    }
+
+    @Test
+    @DisplayName("브랜드 이미지 삭제 성공 - 기존 이미지가 없는 경우")
+    void deleteBrandImage_Success_NoExistingImage() {
+        // given
+        seller = Sellers.builder()
+                .userId("user-uuid-123")
+                .user(user)
+                .vendorName("멍멍이네 수제간식")
+                .vendorProfileImage(null) // 기존 이미지 없음
+                .businessNumber("123-45-67890")
+                .build();
+
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // when
+        SellerBrandImageResponseDTO result = sellerBrandImageService.deleteBrandImage(userPrincipal);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // S3 삭제는 호출되지 않아야 함
+        verify(objectStorageService, never()).deleteImage(anyString());
+
+        // 판매자 정보 저장은 호출되어야 함
+        verify(sellersRepository).save(seller);
+    }
+
+    @Test
+    @DisplayName("이미지 파일 유효성 검증 실패 - null 파일")
+    void uploadBrandImage_Fail_NullFile() {
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 파일이 비어있습니다.");
+    }
+
+    @Test
+    @DisplayName("이미지 파일 유효성 검증 실패 - 빈 파일")
+    void uploadBrandImage_Fail_EmptyFile() {
+        // given
+        MultipartFile emptyFile = new MockMultipartFile(
+                "image", "empty.jpg", "image/jpeg", new byte[0]
+        );
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, emptyFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 파일이 비어있습니다.");
+    }
+
+    @Test
+    @DisplayName("이미지 파일 유효성 검증 실패 - 파일 크기 초과")
+    void uploadBrandImage_Fail_FileSizeExceeded() {
+        // given - 11MB 파일 생성
+        byte[] largeContent = new byte[11 * 1024 * 1024];
+        MultipartFile largeFile = new MockMultipartFile(
+                "image", "large.jpg", "image/jpeg", largeContent
+        );
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, largeFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 파일 크기는 10MB를 초과할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이미지 파일 유효성 검증 실패 - 지원하지 않는 파일 형식")
+    void uploadBrandImage_Fail_UnsupportedFileType() {
+        // given
+        MultipartFile textFile = new MockMultipartFile(
+                "file", "document.txt", "text/plain", "text content".getBytes()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, textFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미지 파일만 업로드 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("이미지 파일 유효성 검증 실패 - 지원하지 않는 이미지 형식")
+    void uploadBrandImage_Fail_UnsupportedImageFormat() {
+        // given
+        MultipartFile gifFile = new MockMultipartFile(
+                "image", "animated.gif", "image/gif", "gif content".getBytes()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, gifFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지원하지 않는 이미지 형식입니다. (JPEG, PNG, JPG, WebP만 지원)");
+    }
+
+    @Test
+    @DisplayName("사용자 조회 실패")
+    void uploadBrandImage_Fail_UserNotFound() {
+        // given
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("판매자 조회 실패")
+    void uploadBrandImage_Fail_SellerNotFound() {
+        // given
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("판매자 정보를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("S3 업로드 실패로 인한 예외")
+    void uploadBrandImage_Fail_S3UploadError() throws IOException {
+        // given
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenThrow(new RuntimeException("S3 업로드 실패"));
+
+        // when & then
+        assertThatThrownBy(() -> sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("이미지 업로드 실패");
+    }
+
+    @Test
+    @DisplayName("기존 이미지 삭제 실패해도 업로드는 계속 진행")
+    void uploadBrandImage_Success_IgnoreDeleteError() throws IOException {
+        // given
+        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
+
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        doThrow(new RuntimeException("S3 삭제 실패"))
+                .when(objectStorageService).deleteImage("old_brand_image.jpg");
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenReturn(newImageUrl);
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // when
+        SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, validImageFile);
+
+        // then
+        assertThat(result).isNotNull();
+
+        // 기존 이미지 삭제 시도는 했지만 실패
+        verify(objectStorageService).deleteImage("old_brand_image.jpg");
+
+        // 새 이미지 업로드는 성공
+        verify(objectStorageService).uploadImage(anyString(), any(), anyLong(), anyString());
+
+        // 최종 저장도 성공
+        verify(sellersRepository).save(seller);
+    }
+
+    @Test
+    @DisplayName("지원하는 모든 이미지 형식 테스트")
+    void uploadBrandImage_Success_AllSupportedFormats() throws IOException {
+        // given
+        String newImageUrl = "https://cdn.example.com/images/brand_user-uuid_abc123.jpg";
+
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenReturn(newImageUrl);
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        // 지원하는 모든 형식 테스트
+        String[] supportedTypes = {"image/jpeg", "image/png", "image/jpg", "image/webp"};
+        String[] extensions = {"jpeg", "png", "jpg", "webp"};
+
+        for (int i = 0; i < supportedTypes.length; i++) {
+            // given
+            MultipartFile imageFile = new MockMultipartFile(
+                    "image",
+                    "test." + extensions[i],
+                    supportedTypes[i],
+                    "test content".getBytes()
+            );
+
+            // when & then (예외가 발생하지 않아야 함)
+            SellerBrandImageResponseDTO result = sellerBrandImageService.uploadBrandImage(userPrincipal, imageFile);
+            assertThat(result).isNotNull();
+        }
+
+        // 모든 형식에 대해 업로드가 호출되었는지 확인
+        verify(objectStorageService, times(4)).uploadImage(anyString(), any(), anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("파일명에서 확장자 추출 테스트")
+    void extractFileExtension_Test() {
+        // private 메서드이므로 실제로는 업로드를 통해 간접적으로 테스트
+        // given
+        when(userRepository.findByProviderAndProviderId(anyString(), anyString()))
+                .thenReturn(Optional.of(user));
+        when(sellersRepository.findByUserId(anyString()))
+                .thenReturn(Optional.of(seller));
+        when(objectStorageService.uploadImage(anyString(), any(), anyLong(), anyString()))
+                .thenReturn("test-url");
+        when(sellersRepository.save(any(Sellers.class)))
+                .thenReturn(seller);
+
+        MultipartFile pngFile = new MockMultipartFile(
+                "image", "test.PNG", "image/png", "content".getBytes()
+        );
+
+        // when
+        sellerBrandImageService.uploadBrandImage(userPrincipal, pngFile);
+
+        // then
+        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(objectStorageService).uploadImage(fileNameCaptor.capture(), any(), anyLong(), anyString());
+
+        String capturedFileName = fileNameCaptor.getValue();
+        assertThat(capturedFileName).endsWith(".png"); // 소문자로 변환되어야 함
+        assertThat(capturedFileName).matches("brand_123_[a-f0-9]{32}\\.png"); // PNG 확장자 확인
+    }
+}

--- a/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
+++ b/src/test/java/com/team5/catdogeats/users/service/impl/SellerBrandImageServiceImplTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT) 
-@DisplayName("SellerBrandImageServiceImpl 테스트 - 업데이트 버전")
+@DisplayName("SellerBrandImageServiceImpl 테스트")
 class SellerBrandImageServiceImplTest {
 
     @Mock

--- a/src/test/java/com/team5/catdogeats/users/service/impl/SellerInfoServiceImplTest.java
+++ b/src/test/java/com/team5/catdogeats/users/service/impl/SellerInfoServiceImplTest.java
@@ -120,7 +120,6 @@ class SellerInfoServiceImplTest {
 
         testRequest = new SellerInfoRequestDTO(
                 "펫푸드 공방",
-                "https://example.com/logo.jpg",
                 "123-45-67890",
                 "신한은행",
                 "110-123-456789",
@@ -235,7 +234,6 @@ class SellerInfoServiceImplTest {
             String newVendorName = "수정된 Vendor_name";
             SellerInfoRequestDTO updateRequest = new SellerInfoRequestDTO(
                     newVendorName,
-                    testRequest.vendorProfileImage(),
                     testRequest.businessNumber(),
                     testRequest.settlementBank(),
                     testRequest.settlementAcc(),
@@ -300,7 +298,6 @@ class SellerInfoServiceImplTest {
             // given - 상점명만 있고 사업자번호 없음
             SellerInfoRequestDTO incompleteRequest = new SellerInfoRequestDTO(
                     "펫푸드 공방",        // 상점명만 있음
-                    "https://example.com/logo.jpg",
                     null,               // 사업자번호 없음
                     "신한은행",
                     "110-123-456789",
@@ -340,8 +337,8 @@ class SellerInfoServiceImplTest {
                     null,
                     null,
                     null,
-                    null,
                     null
+
             );
 
             given(userRepository.findByProviderAndProviderId("google", "113091084348977764576"))
@@ -414,7 +411,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO invalidRequest = new SellerInfoRequestDTO(
                     "펫푸드 공방",
-                    "https://example.com/logo.jpg",
                     "987-65-43210",
                     "신한은행",
                     "110-123-456789",
@@ -443,7 +439,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO invalidRequest = new SellerInfoRequestDTO(
                     "펫푸드 공방",
-                    "https://example.com/logo.jpg",
                     "987-65-43210",
                     "신한은행",
                     "110-123-456789",
@@ -525,7 +520,6 @@ class SellerInfoServiceImplTest {
             // given - Record 생성자로 null 값들 포함
             SellerInfoRequestDTO requestWithNulls = new SellerInfoRequestDTO(
                     "펫푸드 공방",                          // 필수
-                    "https://example.com/logo.jpg",        // 필수
                     "987-65-43210",                        // 필수 (다른 사업자번호)
                     null,                                  // settlementBank (선택)
                     null,                                  // settlementAcc (선택)
@@ -557,7 +551,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO requestWithEmptyStrings = new SellerInfoRequestDTO(
                     "펫푸드 공방",                          // 필수
-                    "https://example.com/logo.jpg",        // 필수
                     "987-65-43210",                        // 필수
                     "",                                    // 빈 문자열
                     "",                                    // 빈 문자열
@@ -594,7 +587,6 @@ class SellerInfoServiceImplTest {
             // given - 주말 휴무
             SellerInfoRequestDTO weekendRequest = new SellerInfoRequestDTO(
                     "주말휴무 펫샵",
-                    "https://example.com/logo.jpg",
                     "111-11-11111",
                     "신한은행",
                     "110-123-456789",
@@ -624,7 +616,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO singleDayRequest = new SellerInfoRequestDTO(
                     "월요일만 휴무",
-                    "https://example.com/logo.jpg",
                     "222-22-22222",
                     "신한은행",
                     "110-123-456789",
@@ -654,7 +645,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO noClosedDaysRequest = new SellerInfoRequestDTO(
                     "무휴 펫샵",
-                    "https://example.com/logo.jpg",
                     "333-33-33333",
                     "신한은행",
                     "110-123-456789",
@@ -684,7 +674,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO emptyClosedDaysRequest = new SellerInfoRequestDTO(
                     "무휴 펫샵2",
-                    "https://example.com/logo.jpg",
                     "444-44-44444",
                     "신한은행",
                     "110-123-456789",
@@ -714,7 +703,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO manyClosedDaysRequest = new SellerInfoRequestDTO(
                     "주 3일만 운영",
-                    "https://example.com/logo.jpg",
                     "555-55-55555",
                     "신한은행",
                     "110-123-456789",
@@ -744,7 +732,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO invalidRequest = new SellerInfoRequestDTO(
                     "잘못된 요일",
-                    "https://example.com/logo.jpg",
                     "333-33-33333",
                     "신한은행",
                     "110-123-456789",
@@ -773,7 +760,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO partiallyInvalidRequest = new SellerInfoRequestDTO(
                     "부분 잘못",
-                    "https://example.com/logo.jpg",
                     "444-44-44444",
                     "신한은행",
                     "110-123-456789",
@@ -798,7 +784,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO spacedDaysRequest = new SellerInfoRequestDTO(
                     "공백 포함 요일",
-                    "https://example.com/logo.jpg",
                     "777-77-77777",
                     "신한은행",
                     "110-123-456789",
@@ -833,7 +818,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO onlyStartTimeRequest = new SellerInfoRequestDTO(
                     "시작시간만 설정",
-                    "https://example.com/logo.jpg",
                     "888-88-88888",
                     "신한은행",
                     "110-123-456789",
@@ -862,7 +846,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO onlyEndTimeRequest = new SellerInfoRequestDTO(
                     "종료시간만 설정",
-                    "https://example.com/logo.jpg",
                     "999-99-99999",
                     "신한은행",
                     "110-123-456789",
@@ -887,7 +870,6 @@ class SellerInfoServiceImplTest {
             // given
             SellerInfoRequestDTO bothTimesNullRequest = new SellerInfoRequestDTO(
                     "시간 미설정",
-                    "https://example.com/logo.jpg",
                     "000-00-00000",
                     "신한은행",
                     "110-123-456789",


### PR DESCRIPTION
# 📌 PR 제목
[feat] 회원기능 - 판매자 브랜드 이미지 업로드

---

# 📄 개요
- 판매자 브랜드 이미지 업로드(s3) 기능 추가 

---

# ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [x] 기능 구현
- [ ] UI/UX 수정
- [x] API 연동
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [x] 문서 작성

---

# 📃 작업 세부 내용

## 🎯 핵심 기능
- **판매자 브랜드 이미지 업로드/수정**: 기존 이미지 교체 및 새로운 브랜드 이미지 등록
- **판매자 브랜드 이미지 삭제**: S3 파일 삭제 및 DB 참조 제거
- **이미지 파일 유효성 검증**: Magic Number 기반 실제 파일 형식 검증

## 📋 **구현된 보안 기능 목록**

| 보안 기능 | 구현 상태 | 메서드명 | 설명 |
|---------|---------|---------|------|
| ✅ **Magic Number 검증** | 구현완료 | `validateFileSignature()` | JPEG(FF D8 FF), PNG(89 50 4E 47), WebP(RIFF...WEBP) 실제 파일 시그니처 확인 |
| ✅ **MIME Type 검증** | 추가필요 | `validateMimeType()` | HTTP Content-Type 헤더 조작 공격 방지 |
| ✅ **스크립트 공격 방지** | 추가필요 | `validateNoScriptContent()` | 파일 내 악성 스크립트 탐지 및 차단 |
| ✅ **파일명 보안 검증** | 추가필요 | `validateFileName()` | 경로 순회, 특수문자, 위험 확장자 차단 |
| ✅ **파일 크기 제한** | 구현완료 | `validateImageFile()` | 10MB 업로드 제한으로 서버 리소스 보호 |
| ✅ **파일명 정화** | 구현완료 | `getFileExtension()` | 위험한 문자 제거 `[^a-zA-Z0-9._-]` |
| ✅ **화이트리스트 방식** | 구현완료 | `getFileExtension()` | JPEG, PNG, WebP 형식만 허용 |
| ✅ **UUID 파일명 생성** | 구현완료 | `generateUniqueFileName()` | 고유한 파일명으로 충돌 및 예측 방지 |

## 🏗️ 구현 아키텍처
- **Service Layer**: `SellerBrandImageService` 인터페이스 및 구현체
- **Controller Layer**: `SellerBrandImageController` RESTful API 엔드포인트
- **Exception Handler**: `SellerBrandImageExceptionHandler` 전용 예외 처리
- **DTO**: `SellerBrandImageResponseDTO` 응답 표준화

## 📡 API 엔드포인트
```http
PATCH /v1/sellers/image - 브랜드 이미지 업로드/수정
DELETE /v1/sellers/image - 브랜드 이미지 삭제
```

## 🧪 **테스트 커버리지**

### ✅ **성공 시나리오**
- **다양한 이미지 형식 업로드**: JPEG, PNG, WebP 파일 정상 업로드 처리
- **기존 이미지 교체**: 새 이미지 업로드 시 기존 이미지 자동 삭제
- **브랜드 이미지 삭제**: S3 및 DB에서 완전 삭제 처리
- **파일명 생성**: UUID 기반 고유 파일명 생성 검증
- **URL 파싱**: 다양한 URL 형식에서 이미지 키 추출

### ❌ **실패 시나리오**
- **파일 검증 실패**: NULL, 빈 파일, 크기 초과(10MB+)
- **지원하지 않는 형식**: PDF, 텍스트 등 비이미지 파일
- **엔티티 조회 실패**: 사용자/판매자 정보 부재
- **외부 서비스 실패**: S3 업로드/삭제 오류 처리
- **DB 업데이트 실패**: 이미지 URL 삭제 실패 시 예외 처리

### 🛡️ **보안 테스트**
- **MIME Type 검증**: 잘못된 Content-Type 차단
- **Magic Number 검증**: 파일 시그니처 위조 탐지
- **스크립트 공격 방지**: 악성 스크립트 포함 파일 차단
- **파일명 보안**: 경로 순회, 특수문자, 실행파일 확장자 차단
- **이중 보안**: MIME Type + 파일 시그니처 동시 검증

### 🔧 **Edge Case**
- **짧은 userId**: 8자 이하 사용자 ID 파일명 생성
- **기존 이미지 없음**: 삭제할 이미지가 없는 경우 정상 처리
- **URL 파싱 예외**: 잘못된 URL 형식 안전 처리
- **파일명 특수문자**: 다양한 특수문자 정화 처리
- **바이너리 데이터**: 스크립트 패턴 검사 시 인코딩 처리

## 📁 추가된 파일
```
src/main/java/com/team5/catdogeats/users/
├── controller/
│   ├── SellerBrandImageController.java
│   └── SellerBrandImageExceptionHandler.java
├── domain/dto/
│   └── SellerBrandImageResponseDTO.java
├── service/
│   ├── SellerBrandImageService.java
│   └── impl/SellerBrandImageServiceImpl.java
└── repository/
    └── SellersRepository.java (메서드 추가)

src/test/java/com/team5/catdogeats/users/service/impl/
└── SellerBrandImageServiceImplTest.java
```

---

# 🔍 관련 이슈
- 이슈번호: #53 

---
