### PR TITLE
[fix] 공지사항 관리자 컨트롤러 - 세션 인증, 로깅 추가

### DIFF
--- a/src/main/java/com/team5/catdogeats/support/domain/notice/controller/NoticeAdminController.java
+++ b/src/main/java/com/team5/catdogeats/support/domain/notice/controller/NoticeAdminController.java
@@ -1,11 +1,15 @@
 package com.team5.catdogeats.support.domain.notice.controller;
 
+import com.team5.catdogeats.admins.domain.dto.AdminInfo;
+import com.team5.catdogeats.admins.util.AdminControllerUtils;
 import com.team5.catdogeats.global.dto.APIResponse;
 import com.team5.catdogeats.global.enums.ResponseCode;
 import com.team5.catdogeats.support.domain.notice.dto.*;
 import com.team5.catdogeats.support.domain.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +17,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.http.MediaType;
@@ -23,10 +29,12 @@ import java.util.*;
 @RequestMapping("/v1/admin/notices")
 @RequiredArgsConstructor
 @Slf4j
+@PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Notice (Admin)", description = "공지사항 관리자 API - 관리자만 접근 가능")
 public class NoticeAdminController {
 
     private final NoticeService noticeService;
+    private final AdminControllerUtils controllerUtils;
 
     // ========== 공지사항 목록 조회 ==========
     @GetMapping
@@ -36,13 +44,32 @@ public class NoticeAdminController {
                     "sortBy: latest(최신순, 기본값), oldest(오래된순), views(조회순)"
     )
     public ResponseEntity<APIResponse<NoticeListResponseDTO>> getNotices(
+            HttpSession session,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String search,
             @RequestParam(defaultValue = "latest") String sortBy) {
 
-        NoticeListResponseDTO response = noticeService.getNotices(page, size, search, sortBy);
-        return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
+            log.info("관리자 공지사항 목록 조회 - adminId: {}, adminName: {}",
+                    adminInfo.adminId(), adminInfo.name());
+
+            NoticeListResponseDTO response = noticeService.getNotices(page, size, search, sortBy);
+            return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 공지사항 목록 조회 시도, error: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
+        } catch (Exception e) {
+            log.error("관리자 공지사항 목록 조회 중 서버 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR)
+            );
+        }
     }
 
     // ========== 공지사항 상세 조회 ==========
@@ -51,17 +78,31 @@ public class NoticeAdminController {
             summary = "공지사항 상세 조회",
             description = "관리자 페이지에서 공지사항 상세 내용을 조회합니다."
     )
-    public ResponseEntity<APIResponse<NoticeResponseDTO>> getNotice(@PathVariable String noticeId) {
+    public ResponseEntity<APIResponse<NoticeResponseDTO>> getNotice(
+            HttpSession session,
+            @PathVariable String noticeId) {
 
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
             NoticeResponseDTO response = noticeService.getNotice(noticeId);
+
+            log.info("관리자 공지사항 상세 조회 완료 - noticeId: {}, adminId: {}, adminName: {}",
+                    noticeId, adminInfo.adminId(), adminInfo.name());
+
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - noticeId: {}, error: {}", noticeId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
         } catch (NoSuchElementException e) {
             log.error("Notice not found: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(APIResponse.error(ResponseCode.ENTITY_NOT_FOUND, e.getMessage()));
         } catch (Exception e) {
-            log.error("Unexpected error: ", e);
+            log.error("관리자 공지사항 상세 조회 중 서버 오류 - noticeId: {}", noticeId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -74,13 +115,30 @@ public class NoticeAdminController {
             description = "관리자가 공지사항을 등록합니다."
     )
     public ResponseEntity<APIResponse<NoticeResponseDTO>> createNotice(
+            HttpSession session,
             @Valid @RequestBody NoticeCreateRequestDTO requestDto) {
 
-        log.info("[관리자] 공지사항 생성 요청 - 제목: {}", requestDto.getTitle());
+        try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
 
-        NoticeResponseDTO response = noticeService.createNotice(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(APIResponse.success(ResponseCode.CREATED, response));
+            log.info("관리자 공지사항 생성 요청 - 제목: {}, adminId: {}, adminName: {}",
+                    requestDto.getTitle(), adminInfo.adminId(), adminInfo.name());
+
+            NoticeResponseDTO response = noticeService.createNotice(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(APIResponse.success(ResponseCode.CREATED, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 공지사항 생성 시도, error: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
+        } catch (Exception e) {
+            log.error("관리자 공지사항 생성 중 서버 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR)
+            );
+        }
     }
 
     // ========== 공지사항 수정 ==========
@@ -90,13 +148,30 @@ public class NoticeAdminController {
             description = "관리자가 공지사항을 수정합니다."
     )
     public ResponseEntity<APIResponse<NoticeResponseDTO>> updateNotice(
+            HttpSession session,
             @PathVariable String noticeId,
             @Valid @RequestBody NoticeUpdateRequestDTO requestDto) {
 
-        log.info("[관리자] 공지사항 수정 요청 - ID: {}, 제목: {}", noticeId, requestDto.getTitle());
+        try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
 
-        NoticeResponseDTO response = noticeService.updateNotice(noticeId, requestDto);
-        return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+            log.info("관리자 공지사항 수정 요청 - ID: {}, 제목: {}, adminId: {}, adminName: {}",
+                    noticeId, requestDto.getTitle(), adminInfo.adminId(), adminInfo.name());
+
+            NoticeResponseDTO response = noticeService.updateNotice(noticeId, requestDto);
+            return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - noticeId: {}, error: {}", noticeId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
+        } catch (Exception e) {
+            log.error("관리자 공지사항 수정 중 서버 오류 - noticeId: {}", noticeId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR)
+            );
+        }
     }
 
     // ========== 공지사항 삭제 ==========
@@ -105,18 +180,30 @@ public class NoticeAdminController {
             summary = "공지사항 삭제",
             description = "관리자가 공지사항을 삭제합니다."
     )
-    public ResponseEntity<APIResponse<Void>> deleteNotice(@PathVariable String noticeId) {
-        log.info("[관리자] 공지사항 삭제 요청 - ID: {}", noticeId);
+    public ResponseEntity<APIResponse<Void>> deleteNotice(
+            HttpSession session,
+            @PathVariable String noticeId) {
 
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
+            log.info("관리자 공지사항 삭제 요청 - ID: {}, adminId: {}, adminName: {}",
+                    noticeId, adminInfo.adminId(), adminInfo.name());
+
             noticeService.deleteNotice(noticeId);
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - noticeId: {}, error: {}", noticeId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
         } catch (NoSuchElementException e) {
             log.error("Notice not found: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(APIResponse.error(ResponseCode.ENTITY_NOT_FOUND, e.getMessage()));
         } catch (Exception e) {
-            log.error("Unexpected error: ", e);
+            log.error("관리자 공지사항 삭제 중 서버 오류 - noticeId: {}", noticeId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -129,25 +216,38 @@ public class NoticeAdminController {
             description = "관리자가 공지사항의 첨부파일을 업로드합니다."
     )
     public ResponseEntity<APIResponse<NoticeResponseDTO>> uploadFile(
+            HttpSession session,
             @PathVariable String noticeId,
             @RequestParam("file") MultipartFile file) {
 
-        // 기본적인 파일 존재 여부만 Controller에서 체크
-        if (file.isEmpty()) {
-            return ResponseEntity.badRequest()
-                    .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, "업로드할 파일을 선택해주세요."));
-        }
-
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
+            // 기본적인 파일 존재 여부만 Controller에서 체크
+            if (file.isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, "업로드할 파일을 선택해주세요."));
+            }
+
             // 파일 검증과 비즈니스 로직은 서비스에서 처리
             NoticeResponseDTO response = noticeService.uploadFile(noticeId, file);
+
+            log.info("관리자 파일 업로드 완료 - noticeId: {}, fileName: {}, adminId: {}, adminName: {}",
+                    noticeId, file.getOriginalFilename(), adminInfo.adminId(), adminInfo.name());
+
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 파일 업로드 시도, noticeId: {}, error: {}", noticeId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
         } catch (IllegalArgumentException e) {
-            log.error("[관리자] 파일 업로드 검증 실패 - ID: {}, 오류: {}", noticeId, e.getMessage());
+            log.error("관리자 파일 업로드 검증 실패 - ID: {}, 오류: {}", noticeId, e.getMessage());
             return ResponseEntity.badRequest()
                     .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
         } catch (Exception e) {
-            log.error("[관리자] 파일 업로드 실패 - ID: {}, 오류: {}", noticeId, e.getMessage());
+            log.error("관리자 파일 업로드 실패 - ID: {}, 오류: {}", noticeId, e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -159,11 +259,20 @@ public class NoticeAdminController {
             summary = "공지사항 첨부파일 다운로드",
             description = "관리자 페이지에서 공지사항의 첨부파일을 다운로드합니다."
     )
-    public ResponseEntity<Resource> downloadFile(@PathVariable String noticeId, @PathVariable String fileId) {
+    public ResponseEntity<Resource> downloadFile(
+            HttpSession session,
+            @PathVariable String noticeId,
+            @PathVariable String fileId) {
 
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
             // 서비스에서 DTO로 받아오기
             NoticeFileDownloadResponseDTO downloadResponse = noticeService.downloadFile(fileId);
+
+            log.info("관리자 파일 다운로드 완료 - noticeId: {}, fileId: {}, fileName: {}, adminId: {}, adminName: {}",
+                    noticeId, fileId, downloadResponse.getFilename(), adminInfo.adminId(), adminInfo.name());
 
             // DTO에서 필요한 정보 추출해서 ResponseEntity 구성
             return ResponseEntity.ok()
@@ -173,10 +282,13 @@ public class NoticeAdminController {
                     .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
                     .header(HttpHeaders.PRAGMA, "no-cache")
                     .header(HttpHeaders.EXPIRES, "0")
-                    .body(downloadResponse.getResource()); // ✅ Resource만 body에 넣기
+                    .body(downloadResponse.getResource());
 
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 파일 다운로드 시도, noticeId: {}, fileId: {}", noticeId, fileId);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         } catch (Exception e) {
-            log.error("파일 다운로드 실패 - 파일 ID: {}, 오류: {}", fileId, e.getMessage());
+            log.error("관리자 파일 다운로드 실패 - 파일 ID: {}, 오류: {}", fileId, e.getMessage());
             return ResponseEntity.notFound().build();
         }
     }
@@ -188,12 +300,26 @@ public class NoticeAdminController {
             description = "관리자가 공지사항의 첨부파일을 삭제합니다."
     )
     public ResponseEntity<APIResponse<Void>> deleteFile(
+            HttpSession session,
             @PathVariable String noticeId,
             @PathVariable String fileId) {
 
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
             noticeService.deleteFile(noticeId, fileId);
+
+            log.info("관리자 파일 삭제 완료 - noticeId: {}, fileId: {}, adminId: {}, adminName: {}",
+                    noticeId, fileId, adminInfo.adminId(), adminInfo.name());
+
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 파일 삭제 시도, noticeId: {}, fileId: {}, error: {}",
+                    noticeId, fileId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
         } catch (NoSuchElementException e) {
             log.error("File or Notice not found: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -203,7 +329,7 @@ public class NoticeAdminController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
         } catch (Exception e) {
-            log.error("Unexpected error during file deletion: ", e);
+            log.error("관리자 파일 삭제 중 서버 오류 - noticeId: {}, fileId: {}", noticeId, fileId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -216,20 +342,34 @@ public class NoticeAdminController {
             description = "관리자가 공지사항의 첨부파일을 새 파일로 수정(교체)합니다."
     )
     public ResponseEntity<APIResponse<NoticeResponseDTO>> replaceFile(
+            HttpSession session,
             @PathVariable String noticeId,
             @PathVariable String fileId,
             @RequestParam("file") MultipartFile newFile) {
 
-        // 기본적인 파일 존재 여부만 Controller에서 체크
-        if (newFile.isEmpty()) {
-            return ResponseEntity.badRequest()
-                    .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, "수정(교체)할 파일을 선택해주세요."));
-        }
-
         try {
+            // 세션 인증 추가
+            AdminInfo adminInfo = controllerUtils.requireSessionInfo(session);
+
+            // 기본적인 파일 존재 여부만 Controller에서 체크
+            if (newFile.isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, "수정(교체)할 파일을 선택해주세요."));
+            }
+
             // 파일 검증과 비즈니스 로직은 서비스에서 처리
             NoticeResponseDTO response = noticeService.replaceFile(noticeId, fileId, newFile);
+
+            log.info("관리자 파일 교체 완료 - noticeId: {}, fileId: {}, newFileName: {}, adminId: {}, adminName: {}",
+                    noticeId, fileId, newFile.getOriginalFilename(), adminInfo.adminId(), adminInfo.name());
+
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, response));
+        } catch (BadCredentialsException e) {
+            log.warn("관리자 로그인 필요 - 파일 교체 시도, noticeId: {}, fileId: {}, error: {}",
+                    noticeId, fileId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    APIResponse.error(ResponseCode.UNAUTHORIZED, "관리자 로그인이 필요합니다")
+            );
         } catch (NoSuchElementException e) {
             log.error("File or Notice not found: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -239,7 +379,7 @@ public class NoticeAdminController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE, e.getMessage()));
         } catch (Exception e) {
-            log.error("Unexpected error during file replacement: ", e);
+            log.error("관리자 파일 교체 중 서버 오류 - noticeId: {}, fileId: {}", noticeId, fileId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 기능 구현 -->
[fix] 공지사항 관리자 컨트롤러 - 세션 인증, 로깅 추가

---

## 📄 개요
<!-- 이 PR에서 변경된 주요 내용을 요약해주세요 -->
- 공지사항 관리자 컨트롤러에 세션 인증, 로깅 추가했습니다.

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [x] 기능 구현
- [ ] UI/UX 수정
- [ ] API 연동
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서 작성

---

## 📃 작업 세부 내용

<!-- 어떤 작업을 했는지 세부 내용을 작성해주세요 (이미치 첨부 가능) -->



---

## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (예: #23) -->
- #113 

---

## 📝 참고 사항
<!-- 리뷰어가 참고할 만한 내용을 자유롭게 작성해주세요 -->
- 

---

## 🙏 리뷰 요청 사항
<!-- 특별히 리뷰어에게 받고 싶은 피드백이 있다면 작성해주세요 -->
- 
