### PR TITLE
fix: 삭제된 판매자 상품 제외한 상품 조회

### DIFF
--- a/src/main/java/com/team5/catdogeats/products/controller/ProductController.java
+++ b/src/main/java/com/team5/catdogeats/products/controller/ProductController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1")
@@ -115,19 +117,50 @@ public class ProductController {
     }
 
     @Operation(
+            summary = "판매자 상품 목록 조회",
+            description = "판매자가 본인의 상품 목록을 조회합니다."
+    )
+    @GetMapping("/sellers/products")
+    public ResponseEntity<APIResponse<Page<SellerProductListProjection>>> getSellerProducts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(defaultValue="0") int page,
+            @RequestParam(defaultValue="10") int size) {
+        if (userPrincipal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(APIResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+        if (page < 0) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(APIResponse.error(ResponseCode.INVALID_INPUT_VALUE));
+        }
+        try {
+            Page<SellerProductListProjection> result = productService.getSellerProductList(userPrincipal, page, size);
+            return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS, result));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(APIResponse.error(ResponseCode.ACCESS_DENIED));
+        } catch (Exception e) {
+            log.error("Exception in getSellerProducts", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+
+    @Operation(
             summary = "상품 수정",
             description = "판매자가 기존 상품 정보를 수정합니다. 수정할 상품 ID와 내용을 요청 바디로 전달합니다."
     )
     @PatchMapping("/sellers/products")
     public ResponseEntity<APIResponse<Void>> updateProduct(@RequestBody @Valid @Parameter(description = "수정할 상품 정보", required = true) ProductUpdateRequestDto dto) {
+        log.info("🚩 [PATCH /sellers/products] 요청 도착, dto: {}", dto);
         try {
             productService.updateProduct(dto);
+            log.info("✅ [PATCH /sellers/products] 수정 성공, productId: {}", dto.productId());
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS));
         } catch (NoSuchElementException e) {
+            log.error("❌ [PATCH /sellers/products] NoSuchElementException: {}", e.getMessage());
             return ResponseEntity
                     .status(ResponseCode.ENTITY_NOT_FOUND.getStatus())
                     .body(APIResponse.error(ResponseCode.ENTITY_NOT_FOUND, e.getMessage()));
         } catch (Exception e) {
+            log.error("❌ [PATCH /sellers/products] Exception: {}", e.getMessage());
             return ResponseEntity
                     .status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage()));
@@ -140,14 +173,18 @@ public class ProductController {
     )
     @DeleteMapping("/sellers/products")
     public ResponseEntity<APIResponse<Void>> deleteProduct(@RequestBody @Valid @Parameter(description = "삭제할 상품 id", required = true) ProductDeleteRequestDto dto) {
+        log.info("🚩 [DELETE /sellers/products] 요청 도착, dto: {}", dto);
         try {
             productService.deleteProduct(dto);
+            log.info("✅ [DELETE /sellers/products] 삭제 성공, productId: {}", dto.productId());
             return ResponseEntity.ok(APIResponse.success(ResponseCode.SUCCESS));
         } catch (NoSuchElementException e) {
+            log.error("❌ [DELETE /sellers/products] NoSuchElementException: {}", e.getMessage());
             return ResponseEntity
                     .status(ResponseCode.ENTITY_NOT_FOUND.getStatus())
                     .body(APIResponse.error(ResponseCode.ENTITY_NOT_FOUND, e.getMessage()));
         } catch (Exception e) {
+            log.error("❌ [DELETE /sellers/products] Exception: {}", e.getMessage());
             return ResponseEntity
                     .status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage()));
@@ -216,5 +253,7 @@ public class ProductController {
                     .body(APIResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, e.getMessage()));
         }
     }
+
+
 
 }

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/MainProductProjection.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/MainProductProjection.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 public interface MainProductProjection {
     String getProductId();
+    String getProductNumber();
     String getImageUrl();
     String getVendorName();
     String getTitle();
@@ -12,5 +13,6 @@ public interface MainProductProjection {
     Long getPrice();
     Boolean getIsDiscounted();
     Double getDiscountRate();
+    Long getDiscountedPrice();
     Instant getCreatedAt();
 }

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/MainProductResponseDto.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/MainProductResponseDto.java
@@ -3,6 +3,8 @@ package com.team5.catdogeats.products.domain.dto;
 import java.time.Instant;
 
 public record MainProductResponseDto(
+        String id,
+        String productNumber,
         String imageUrl,
         String vendorName,
         String title,
@@ -11,6 +13,7 @@ public record MainProductResponseDto(
         Long price,
         Boolean isDiscounted,
         Double discountRate,
+        Long discountedPrice,
         Instant createdAt
 ) {
 }

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/MyProductResponseDto.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/MyProductResponseDto.java
@@ -3,6 +3,7 @@ package com.team5.catdogeats.products.domain.dto;
 // 특정 sellerId로 상품 조회시 response
 public record MyProductResponseDto(
     String productId,
+    String productNumber,
     String productName,
     Long reviewCount,
     Double averageStar,

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/ProductDetailProjection.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/ProductDetailProjection.java
@@ -9,6 +9,7 @@ public interface ProductDetailProjection {
     String getContents();
     Boolean getIsDiscounted();
     Double getDiscountRate();
+    Long getDiscountedPrice();
     Long getPrice();
     List<String> getImages();
     String getVendorName();

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/ProductDetailResponseDto.java
@@ -12,6 +12,7 @@ public record ProductDetailResponseDto(
         boolean isDiscounted,
         Double discountRate,
         Long price,
+        Long discountedPrice,
         @JsonRawValue
         List<String> images,
         String vendorName,

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/ProductListProjection.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/ProductListProjection.java
@@ -18,4 +18,5 @@ public interface ProductListProjection{
     String getProductCategory();
     String get();
     Instant getCreatedAt();
+    Integer getReviewCount();
 }

--- a/src/main/java/com/team5/catdogeats/products/domain/dto/SellerProductListProjection.java
+++ b/src/main/java/com/team5/catdogeats/products/domain/dto/SellerProductListProjection.java
@@ -1,0 +1,16 @@
+// SellerProductListProjection.java
+package com.team5.catdogeats.products.domain.dto;
+
+import java.time.Instant;
+
+public interface SellerProductListProjection {
+    String getImageUrl();
+    String getTitle();
+    String getProductId();
+    Long getProductNumber();
+    String getPetCategory();
+    String getProductCategory();
+    Long getPrice();
+    Integer getStock();
+    Instant getUpdatedAt();
+}

--- a/src/main/java/com/team5/catdogeats/products/mapper/ProductMapper.java
+++ b/src/main/java/com/team5/catdogeats/products/mapper/ProductMapper.java
@@ -14,6 +14,7 @@ public interface ProductMapper {
     <script>
     SELECT
         p.id as productId,
+        p.product_number as productNumber,
         p.title as productName,
         COALESCE(COUNT(r.id), 0) as reviewCount,
         COALESCE(AVG(r.star), 0.0) as averageStar,

--- a/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
+++ b/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
@@ -56,7 +56,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         ORDER BY p.created_at DESC
@@ -64,6 +64,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             countQuery = """
         SELECT COUNT(*)
         FROM products p
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         """,
@@ -102,7 +103,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         ORDER BY p.price DESC
@@ -110,6 +111,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             countQuery = """
         SELECT COUNT(*)
         FROM products p
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         """,
@@ -148,7 +150,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         ORDER BY (
@@ -160,6 +162,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             countQuery = """
         SELECT COUNT(*)
         FROM products p
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE (:petCategory IS NULL OR p.petCategory = :petCategory)
           AND (:productCategory IS NULL OR p.productCategory = :productCategory)
         """,
@@ -201,7 +204,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                   WHERE r.product_id = p.id
                 ) AS reviewCount
             FROM products p
-            JOIN sellers s ON s.user_id = p.seller_id
+            JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
             WHERE p.product_number = :productNumber
             LIMIT 1
         """,
@@ -238,7 +241,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             p.discount_rate AS discountRate,
             p.created_at AS createdAt
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         ORDER BY p.created_at DESC
         LIMIT 8
     """,
@@ -275,7 +278,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             p.discount_rate AS discountRate,
             p.created_at AS createdAt
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         WHERE p.is_discounted = true
         ORDER BY p.discount_rate DESC NULLS LAST
         LIMIT 8
@@ -350,7 +353,7 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 LEAST(100.0, COALESCE(ro.recent_order_count,0)/20.0*100.0) * 0.05
             ) AS bestScore
         FROM products p
-        JOIN sellers s ON s.user_id = p.seller_id
+        JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
         LEFT JOIN sales_data sd ON p.id = sd.product_id
         LEFT JOIN review_data rd ON p.id = rd.product_id
         LEFT JOIN recent_orders ro ON p.id = ro.product_id

--- a/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
+++ b/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
@@ -45,12 +45,18 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 FROM reviews r
                 WHERE r.product_id = p.id
             ) AS averageStar,
+            (
+              SELECT COUNT(*)
+              FROM reviews r
+              WHERE r.product_id = p.id
+            ) AS reviewCount,
             p.price,
+            p.product_number as productNumber,
             p.discount_rate AS discountRate,
-            p.is_discounted AS isDiscounted,
+            p.discounted AS isDiscounted,
+            p.discounted_price AS discountedPrice,
             p.petCategory,
             p.productCategory,
-            p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
         JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
@@ -92,12 +98,18 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 FROM reviews r
                 WHERE r.product_id = p.id
             ) AS averageStar,
+            (
+              SELECT COUNT(*)
+              FROM reviews r
+              WHERE r.product_id = p.id
+            ) AS reviewCount,
             p.price,
+            p.product_number as productNumber,
             p.discount_rate AS discountRate,
-            p.is_discounted AS isDiscounted,
+            p.discounted AS isDiscounted,
+            p.discounted_price AS discountedPrice,
             p.petCategory,
             p.productCategory,
-            p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
         JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
@@ -139,12 +151,18 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 FROM reviews r
                 WHERE r.product_id = p.id
             ) AS averageStar,
+            (
+              SELECT COUNT(*)
+              FROM reviews r
+              WHERE r.product_id = p.id
+            ) AS reviewCount,
             p.price,
+            p.product_number as productNumber,
             p.discount_rate AS discountRate,
-            p.is_discounted AS isDiscounted,
+            p.discounted AS isDiscounted,
+            p.discounted_price AS discountedPrice,
             p.petCategory,
             p.productCategory,
-            p.stock_status AS stockStatus,
             p.created_at AS createdAt
         FROM products p
         JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
@@ -179,9 +197,10 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 p.subtitle AS subTitle,
                 p.productinfo AS productInfo,
                 p.contents AS contents,
-                p.is_discounted AS isDiscounted,
+                p.discounted AS isDiscounted,
                 p.discount_rate AS discountRate,
                 p.price AS price,
+                p.discounted_price AS discountedPrice,
                 -- 이미지 여러 장 json 배열로
                 (
                   SELECT COALESCE(json_agg(i.image_url), '[]')
@@ -233,9 +252,12 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 FROM reviews r
                 WHERE r.product_id = p.id
             ) AS reviewCount,
+            p.id AS productId,
+            p.product_number AS productNumber,
             p.price,
-            p.is_discounted AS isDiscounted,
+            p.discounted AS isDiscounted,
             p.discount_rate AS discountRate,
+            p.discounted_price AS discountedPrice,
             p.created_at AS createdAt
         FROM products p
         JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
@@ -271,12 +293,15 @@ public interface ProductRepository extends JpaRepository<Products, String> {
                 WHERE r.product_id = p.id
             ) AS reviewCount,
             p.price,
-            p.is_discounted AS isDiscounted,
+            p.id AS productId,
+            p.product_number AS productNumber,
+            p.discounted AS isDiscounted,
             p.discount_rate AS discountRate,
+            p.discounted_price AS discountedPrice,
             p.created_at AS createdAt
         FROM products p
         JOIN sellers s ON s.user_id = p.seller_id AND s.is_deleted = false
-        WHERE p.is_discounted = true
+        WHERE p.discounted = true
         ORDER BY p.discount_rate DESC NULLS LAST
         LIMIT 8
     """,
@@ -331,11 +356,14 @@ public interface ProductRepository extends JpaRepository<Products, String> {
             ) AS imageUrl,
             s.vendor_name AS vendorName,
             p.title AS title,
+            p.id AS productId,
+            p.product_number AS productNumber,
             COALESCE(rd.avg_rating, 0.0) AS averageStar,
             COALESCE(rd.review_count, 0) AS reviewCount,
             p.price,
-            p.is_discounted AS isDiscounted,
+            p.discounted AS isDiscounted,
             p.discount_rate AS discountRate,
+            p.discounted_price AS discountedPrice,
             p.created_at AS createdAt,
             (
                 -- 판매량 정규화(0~100) * 0.4

--- a/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
+++ b/src/main/java/com/team5/catdogeats/products/repository/ProductRepository.java
@@ -1,10 +1,7 @@
 package com.team5.catdogeats.products.repository;
 
 import com.team5.catdogeats.products.domain.Products;
-import com.team5.catdogeats.products.domain.dto.MainProductProjection;
-import com.team5.catdogeats.products.domain.dto.ProductDetailProjection;
-import com.team5.catdogeats.products.domain.dto.ProductInventoryProjection;
-import com.team5.catdogeats.products.domain.dto.ProductListProjection;
+import com.team5.catdogeats.products.domain.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -414,5 +411,38 @@ public interface ProductRepository extends JpaRepository<Products, String> {
        OR lower(p.subTitle) LIKE lower(concat('%', :keyword, '%'))
     """)
     Page<ProductInventoryProjection> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query(value = """
+    SELECT 
+        (
+            SELECT i.image_url
+            FROM products_images pi
+            JOIN images i ON i.id = pi.product_image_id
+            WHERE pi.product_id = p.id
+            ORDER BY pi.created_at
+            LIMIT 1
+        ) AS imageUrl,
+        p.title AS title,
+        p.id AS productId,
+        p.product_number AS productNumber,
+        p.petcategory::text AS petCategory,
+        p.productcategory::text AS productCategory,
+        CAST(p.price AS bigint) AS price,         -- ★ 반드시 CAST!
+        CAST(p.stock AS integer) AS stock,        -- ★ 반드시 CAST!
+        p.updated_at AS updatedAt
+    FROM products p
+    WHERE p.seller_id = :sellerId
+    ORDER BY p.updated_at DESC
+    """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM products p
+        WHERE p.seller_id = :sellerId
+    """,
+            nativeQuery = true)
+    Page<SellerProductListProjection> findSellerProductsBySellerId(
+            @Param("sellerId") String sellerId,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/team5/catdogeats/products/service/ProductService.java
+++ b/src/main/java/com/team5/catdogeats/products/service/ProductService.java
@@ -28,4 +28,6 @@ public interface ProductService {
     ProductDetailResponseDto getProductDetail(Long productNumber);
 
     List<MainProductResponseDto> getMainProducts(MainProductSortType type);
+
+    Page<SellerProductListProjection> getSellerProductList(UserPrincipal userPrincipal, int page, int size);
 }

--- a/src/main/java/com/team5/catdogeats/products/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/products/service/impl/ProductServiceImpl.java
@@ -22,6 +22,7 @@ import com.team5.catdogeats.users.repository.SellersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -161,6 +162,15 @@ public class ProductServiceImpl implements ProductService {
                         p.getCreatedAt()
                 ))
                 .toList();
+    }
+
+    @Override
+    public Page<SellerProductListProjection> getSellerProductList(UserPrincipal userPrincipal, int page, int size) {
+        String sellerId = sellerRepository.findSellerDtoByProviderAndProviderId(
+                        userPrincipal.provider(), userPrincipal.providerId()
+                ).orElseThrow(() -> new NoSuchElementException("해당 유저 정보를 찾을 수 없습니다."))
+                .userId();
+        return productRepository.findSellerProductsBySellerId(sellerId, PageRequest.of(page, size));
     }
 
 

--- a/src/main/java/com/team5/catdogeats/products/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/products/service/impl/ProductServiceImpl.java
@@ -135,6 +135,7 @@ public class ProductServiceImpl implements ProductService {
                 projection.getIsDiscounted() != null && projection.getIsDiscounted(),
                 projection.getDiscountRate(),
                 projection.getPrice(),
+                projection.getDiscountedPrice(),
                 projection.getImages(),
                 projection.getVendorName(),
                 projection.getAverageStar(),
@@ -151,6 +152,8 @@ public class ProductServiceImpl implements ProductService {
         };
         return projections.stream()
                 .map(p -> new MainProductResponseDto(
+                        p.getProductId(),
+                        p.getProductNumber(),
                         p.getImageUrl(),
                         p.getVendorName(),
                         p.getTitle(),
@@ -159,6 +162,7 @@ public class ProductServiceImpl implements ProductService {
                         p.getPrice(),
                         p.getIsDiscounted(),
                         p.getDiscountRate(),
+                        p.getDiscountedPrice(),
                         p.getCreatedAt()
                 ))
                 .toList();

--- a/src/main/java/com/team5/catdogeats/storage/service/impl/ReviewImageSerivceImpl.java
+++ b/src/main/java/com/team5/catdogeats/storage/service/impl/ReviewImageSerivceImpl.java
@@ -156,6 +156,6 @@ public class ReviewImageSerivceImpl implements ReviewImageService {
         String shortReviewId = reviewId.length() > 8 ? reviewId.substring(0, 8) : reviewId;
 
         // 처음 8자리만 사용 (너무 길어지는 것 방지)
-        return String.format("fail_review_%s_%s.%s", shortReviewId, uuid, extension);
+        return String.format("review_%s_%s.%s", shortReviewId, uuid, extension);
     }
 }

--- a/src/main/java/com/team5/catdogeats/users/service/impl/SellerRatingServiceImpl.java
+++ b/src/main/java/com/team5/catdogeats/users/service/impl/SellerRatingServiceImpl.java
@@ -46,6 +46,7 @@ public class SellerRatingServiceImpl implements SellerRatingService {
         List<MyProductResponseDto> fixedDtos = dtos.stream()
                 .map(dto -> new MyProductResponseDto(
                         dto.productId(),
+                        dto.productNumber(),
                         dto.productName(),
                         dto.reviewCount(),
                         dto.averageStar() != null ? Math.round(dto.averageStar() * 10) / 10.0 : 0.0,


### PR DESCRIPTION
## 📌 PR 제목
fix: 삭제된 판매자 상품 제외한 상품 조회

---

## 📄 개요
상품 조회에 사용하는 repo의 메서드들 query 조건문 추가 
프론트 연동에 맞게 dto 및 query문 수정

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [ ] 기능 구현
- [ ] UI/UX 수정
- [ ] API 연동
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서 작성

---

## 📃 작업 세부 내용
ProductRepository의 아래 7개만 수정. (구매자가 보는 상품 목록 조회와 관련된 것들만)
findAllByOrderByCreatedAtDesc / findAllByOrderByDiscountedPriceDesc / findAllByOrderByAverageStarDesc findProductDetailByProductNumber / findTop8ByOrderByCreatedAtDesc / findTop8ByOrderByDiscountRateDesc / findTop8ByBestScoreDesc 

Sellers의 is_deleted=false인 상품들만 조회하도록 Query문 수정.

front연동에 맞게 dto 및 query문 수정

---

## 🔍 관련 이슈
#119 

---

## 📝 참고 사항


---

## 🙏 리뷰 요청 사항

